### PR TITLE
Added missing translation from /done in en and de.

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -606,6 +606,7 @@ de:
     deferred_actions_empty: "Es gibt keine aufgeschobenen Aufgaben f\xC3\xBCr dieses Projekt"
     project_state: Projekt ist %{state}
     no_last_completed_projects: Keine abgeschlossene Projekte gefunden
+    no_last_completed_recurring_todos: "Keine abgeschlossene sich wiederholende To-Dos gefunden"
     todos_append: an dieses Projekt
     notes: Notizen
     notes_empty: "Es gibt keine Notizen f\xC3\xBCr dieses Projekt"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,6 +296,7 @@ en:
     notes: "Notes"
     notes_empty: "There are no notes for this project"
     no_last_completed_projects: "No completed projects found"
+    no_last_completed_recurring_todos: "No completed recurring todos found"
     settings: "Settings"
     state: "This project is %{state}"
     this_project: "This project"


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #2](https://www.assembla.com/spaces/tracks-tickets/tickets/2), now #1469._

This is a minor fix for a missing internationalization string.

TODO: Same translation for other languages (these were the only two I
know)

-Mickey

PS. http://getontracks.org/wiki/Contributors was down when I checked it; so I'm sorry if this doesn't conform to your usual contribution standards.

The error message was: 

```
Error

The following tag cannot be processed:

{exp:wiki}

Please check that the ‘wiki’ module is installed and that ‘wiki’ is an available method of the module
```
