### PR TITLE
Cleanup the environment files after converting to Bundler

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -21,16 +21,6 @@ Rails::Initializer.run do |config|
   # config.frameworks -= [ :action_web_service, :action_mailer ]
   config.autoload_paths += %W( #{RAILS_ROOT}/app/apis )
 
-  config.gem "highline"
-  config.gem "RedCloth", :lib => 'redcloth', :version => '4.2.3'
-  config.gem "soap4r", :lib => false
-  config.gem 'actionwebservice'
-  config.gem 'sanitize', :version => '~> 1.2.1'
-  config.gem 'rack', :version => '1.1.0'
-  config.gem 'will_paginate', :version => '~> 2.3.15'
-  config.gem 'has_many_polymorphs'
-  config.gem 'aasm', :version => '2.2.0'
-
   config.action_controller.use_accept_header = true
 
   # Use the database for sessions instead of the file system
@@ -71,11 +61,6 @@ Rails::Initializer.run do |config|
   # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
   # config.i18n.default_locale = :de
 
-  # See Rails::Configuration for more options
-  if ( SITE_CONFIG['authentication_schemes'].include? 'cas')
-    #requires rubycas-client gem to be installed
-    config.gem "rubycas-client", :lib => 'casclient'
-  end
 end
 
 # Add new inflection rules using the following format

--- a/config/environments/cucumber.rb
+++ b/config/environments/cucumber.rb
@@ -26,8 +26,3 @@ config.action_mailer.delivery_method = :test
 config.action_controller.session_store = :cookie_store
 config.action_controller.session = { :key => 'TracksCucumber', :secret => SITE_CONFIG['salt'] * (30.0 /  SITE_CONFIG['salt'].length).ceil }
 
-config.gem 'cucumber',         :lib => false, :version => '=0.9.4' unless File.directory?(File.join(Rails.root, 'vendor/plugins/cucumber'))
-config.gem 'cucumber-rails',   :lib => false, :version => '=0.3.2' unless File.directory?(File.join(Rails.root, 'vendor/plugins/cucumber-rails'))
-config.gem 'gherkin',          :lib => false, :version => '=2.4.0'   unless File.directory?(File.join(Rails.root, 'vendor/plugins/gherkin'))
-config.gem 'database_cleaner', :lib => false, :version => '>=0.5.0' unless File.directory?(File.join(Rails.root, 'vendor/plugins/database_cleaner'))
-config.gem 'webrat',           :lib => false, :version => '>=0.7.0' unless File.directory?(File.join(Rails.root, 'vendor/plugins/webrat'))

--- a/config/environments/selenium.rb
+++ b/config/environments/selenium.rb
@@ -24,6 +24,3 @@ config.action_mailer.delivery_method = :test
 # Unique cookies
 config.action_controller.session = { :key => 'TracksSelenium' }
 
-config.gem 'database_cleaner', :lib => false, :version => '>=0.5.0' unless File.directory?(File.join(Rails.root, 'vendor/plugins/database_cleaner'))
-config.gem 'selenium-client',  :lib => false unless File.directory?(File.join(Rails.root, 'vendor/plugins/selenium-client'))
-config.gem 'mongrel'  # required by webrat for selenium

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,10 +36,3 @@ config.after_initialize do
   require File.expand_path(File.dirname(__FILE__) + "/../../test/selenium_helper")
 end
 
-config.gem "flexmock"
-config.gem "ZenTest", :lib => "zentest", :version => ">=4.0.0"
-config.gem "hpricot"
-config.gem "hoe"
-config.gem 'webrat',           :lib => false, :version => '>=0.7.0' unless File.directory?(File.join(Rails.root, 'vendor/plugins/webrat'))
-config.gem 'rspec-rails',      :lib => false, :version => '~>1.3.3' unless File.directory?(File.join(Rails.root, 'vendor/plugins/rspec-rails'))
-config.gem "thoughtbot-factory_girl", :lib => "factory_girl", :source => "http://gems.github.com"


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #7](https://www.assembla.com/spaces/tracks-tickets/tickets/7), now #1474._

When using Bundler to resolve your gem dependencies, you do not need
these lines in the environment files.

Thanks to those who pointed this out.

/cc @lrbalt
