### PR TITLE
Decode HTML entities when displaying todos formatted as TXT.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "rubycas-client", "~>2.2.1"
 gem "ruby-openid", :require => "openid"
 gem "sqlite3"
 gem 'bcrypt-ruby', '~> 2.1.4'
+gem 'htmlentities', '~> 4.3.0'
 
 gem "webrat", ">=0.7.0", :groups => [:cucumber, :test]
 gem "database_cleaner", ">=0.5.0", :groups => [:cucumber, :selenium]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     hoe (2.12.0)
       rake (~> 0.8)
     hpricot (0.8.4)
+    htmlentities (4.3.0)
     httpclient (2.2.1)
     json (1.5.3)
     memory_test_fix (0.1.3)
@@ -107,6 +108,7 @@ DEPENDENCIES
   highline (~> 1.5.0)
   hoe
   hpricot
+  htmlentities (~> 4.3.0)
   memory_test_fix (~> 0.1.3)
   mongrel
   rack (= 1.1.0)

--- a/app/views/todos/_text_todo.rhtml
+++ b/app/views/todos/_text_todo.rhtml
@@ -1,4 +1,7 @@
 <% 
+require 'htmlentities'
+htmlentities = HTMLEntities.new
+
 todo = text_todo
 
 if (todo.starred?)
@@ -8,11 +11,11 @@ else
 end
 
 if (todo.completed?) && todo.completed_at
-  result_string << "["+ t('todos.completed') +": " + format_date(todo.completed_at) + "] "
+  result_string << "["+ htmlentities.decode(t('todos.completed')) +": " + format_date(todo.completed_at) + "] "
 end
 
 if todo.due
-  result_string << "[" + t('todos.due') + ": " + format_date(todo.due) + "] "
+  result_string << "[" + htmlentities.decode(t('todos.due')) + ": " + format_date(todo.due) + "] "
   result_string << todo.description + " "
 else
   result_string << todo.description + " "


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #21](https://www.assembla.com/spaces/tracks-tickets/tickets/21), now #1488._

When rendering the text-feed for todos (_text_todo.rhtml) this
uses localized string 'as-is'. Those are html-encoded which
is not appropriate for TXT feeds (e.g. 'todos.due' is 'F&auml;llig'
in German locale).
