### PR TITLE
fix bug #858 by adding information on todos to project xml and providing 

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -107,7 +107,14 @@ class ProjectsController < ApplicationController
     respond_to do |format|
       format.html
       format.m     &render_project_mobile
-      format.xml   { render :xml => @project.to_xml( :except => :user_id )  }
+      format.xml   { 
+        render :xml => @project.to_xml(:except => :user_id) { |xml|
+          xml.not_done { @not_done.each { |child| child.to_xml(:builder => xml, :skip_instruct => true) } }
+          xml.deferred { @deferred.each { |child| child.to_xml(:builder => xml, :skip_instruct => true) } }
+          xml.pending { @pending.each { |child| child.to_xml(:builder => xml, :skip_instruct => true) } }
+          xml.done { @done.each { |child| child.to_xml(:builder => xml, :skip_instruct => true) } }
+        }
+      }
     end
   end
 

--- a/test/integration/project_xml_api_test.rb
+++ b/test/integration/project_xml_api_test.rb
@@ -13,6 +13,16 @@ class ProjectXmlApiTest < ActionController::IntegrationTest
   def setup
     assert_test_environment_ok
   end
+  
+  def test_retrieve_project
+    authenticated_get_xml "/projects/1", users(:admin_user).login, 'abracadabra', {}
+    assert_tag :tag => "project"
+    assert_tag :tag => "project", :child => {:tag => "not_done" }
+    assert_tag :tag => "project", :child => {:tag => "deferred" }
+    assert_tag :tag => "project", :child => {:tag => "pending" }
+    assert_tag :tag => "project", :child => {:tag => "done" }
+    assert_response 200
+  end
 
  def test_fails_with_invalid_xml_format
    #Fails too hard for test to catch


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #30](https://www.assembla.com/spaces/tracks-tickets/tickets/30), now #1497._

fix bug #858 by adding information on todos to project xml and providing a test for it.

http://www.assembla.com/spaces/tracks-tickets/tickets/858-show-completed-defered-tasks-in--projects-id-xml-api#last_comment
