### PR TITLE
fixing #965 - re-adding removed tests - all green

### DIFF
--- a/test/integration/context_xml_api_test.rb
+++ b/test/integration/context_xml_api_test.rb
@@ -49,6 +49,11 @@ class ContextXmlApiTest < ActionController::IntegrationTest
       assert_select 'error', 1, 'Name cannot contain the comma (\',\') character'
     end
   end
+  
+  def test_fails_with_401_if_not_authorized_user	 	
+    authenticated_post_xml_to_context_create @@valid_postdata, 'nobody', 'nohow'
+    assert_response 401
+  end
     
   def test_creates_new_context
     assert_difference 'Context.count' do

--- a/test/integration/project_xml_api_test.rb
+++ b/test/integration/project_xml_api_test.rb
@@ -43,6 +43,11 @@ class ProjectXmlApiTest < ActionController::IntegrationTest
     assert_equal @@project_name, @controller.params[:request][:project][:name]
   end
   
+  def test_fails_with_401_if_not_authorized_user	 	
+    authenticated_post_xml_to_project_create @@valid_postdata, 'nobody', 'nohow'
+    assert_response 401
+  end
+  
   def test_fails_with_too_long_name
     invalid_with_long_name_postdata = "<request><project><name>foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoo arfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoo arfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfo barfoobarfoobarfoobarfoobarfoobarfoobar</name></project></request>"
     authenticated_post_xml_to_project_create invalid_with_long_name_postdata

--- a/test/integration/todo_xml_api_test.rb
+++ b/test/integration/todo_xml_api_test.rb
@@ -2,7 +2,9 @@ require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 require 'todos_controller'
 
 class TodoXmlApiTest < ActionController::IntegrationTest
-  fixtures :users, :contexts, :preferences, :todos
+  fixtures :users, :contexts, :preferences, :todos, :projects
+
+  @@valid_postdata = "<todo><description>this will succeed</description><context_id type='integer'>10</context_id><project_id type='integer'>4</project_id></todo>"
 
   def setup
     assert_test_environment_ok
@@ -33,6 +35,20 @@ class TodoXmlApiTest < ActionController::IntegrationTest
     authenticated_get_xml "/tickler", @user.login, @password, {}
     assert_no_tag :tag => "user_id"
   end
+  
+  def test_create_todo_via_xml_show_from
+    old_count = @user.todos.count
+    authenticated_post_xml_to_todo_create "
+<todo>
+  <description>Call Warren Buffet to find out how much he makes per day</description>
+  <project_id>#{projects(:attendrailsconf).id}</project_id>
+  <context_id>#{contexts(:office_otheruser).id}</context_id>
+  <show-from type=\"datetime\">#{1.week.from_now.xmlschema}</show-from>
+</todo>"
+
+    assert_response :success
+    assert_equal @user.todos.count, old_count + 1
+  end
 
   def test_post_create_todo_with_wrong_project_and_context_id
     authenticated_post_xml_to_todo_create "<todo><description>this will fail</description><context_id type='integer'>-16</context_id><project_id type='integer'>-11</project_id></todo>"
@@ -40,6 +56,11 @@ class TodoXmlApiTest < ActionController::IntegrationTest
     assert_xml_select 'errors' do
       assert_select 'error', 2
     end
+  end
+  
+  def test_fails_with_401_if_not_authorized_user	 	
+    authenticated_post_xml_to_todo_create '', 'nobody', 'nohow'
+    assert_response 401
   end
 
   private


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #32](https://www.assembla.com/spaces/tracks-tickets/tickets/32), now #1499._

http://www.assembla.com/spaces/tracks-tickets/tickets/965-re-create-tests-deleted-in-rails-2-3-5-migration#last_comment
