### PR TITLE
Fix missing links for tags in the recurring todo view

### DIFF
--- a/app/helpers/recurring_todos_helper.rb
+++ b/app/helpers/recurring_todos_helper.rb
@@ -3,9 +3,8 @@ module RecurringTodosHelper
   def recurring_todo_tag_list
     tags_except_starred = @recurring_todo.tags.reject{|t| t.name == Todo::STARRED_TAG_NAME}
     tag_list = tags_except_starred.collect{|t| "<span class=\"tag #{t.name.gsub(' ','-')}\">" +
-        # link_to(t.name, :controller => "todos", :action => "tag", :id =>
-        # t.name) + TODO: tag view for recurring_todos (yet?)
-      t.name +
+        link_to(t.name, :controller => "todos", :action => "tag", :id =>
+        t.name) + #TODO: tag view for recurring_todos (yet?)
         "</span>"}.join('')
     "<span class='tags'>#{tag_list}</span>"
   end


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #35](https://www.assembla.com/spaces/tracks-tickets/tickets/35), now #1502._

The helper method for the recurring todo tag list was missing additions
of the links.

I'm still pretty new to the cucumber + selenium combination, so there's not a test for this, but I did manually test it. :)
