### PR TITLE
Changing the default sort order so that the context view matches the home

### DIFF
--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -1,6 +1,7 @@
 class Context < ActiveRecord::Base
 
-  has_many :todos, :dependent => :delete_all, :include => :project, :order => "todos.completed_at DESC"
+  has_many :todos, :dependent => :delete_all, :include => :project,
+    :order => 'todos.due IS NULL, todos.due ASC, todos.created_at ASC'
   has_many :recurring_todos, :dependent => :delete_all
   belongs_to :user
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #41](https://www.assembla.com/spaces/tracks-tickets/tickets/41), now #1508._

Changing the default sort order so that the context view matches the home screen view.

This appears to override the todos_controller.rb order.
