### PR TITLE
Fix functional tests that wouldn't run

### DIFF
--- a/test/functional/backend_controller_test.rb
+++ b/test/functional/backend_controller_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
-require 'backend_controller'
 
 # Re-raise errors caught by the controller.
 class BackendController; def rescue_action(e) raise e end; end


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #44](https://www.assembla.com/spaces/tracks-tickets/tickets/44), now #1511._

With Ruby 1.8.7, the functional tests were failing due to a recursive
require stack. No longer requiring 'backend_controller' and doesn't seem
to have any bearing on the running of the tests.

This is one of those "i don't understand what it does, but it fixes the problem" types of changes. Additional comments would be welcome. I'm not completely comfortable pushing this outright since I don't understand it completely.
