### PR TITLE
Show deferred if no active actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,8 +91,15 @@ class ApplicationController < ActionController::Base
   #
   def count_undone_todos_phrase(todos_parent, string="actions")
     count = count_undone_todos(todos_parent)
-    word = count == 1 ? string.singularize : string.pluralize
-    return count.to_s + "&nbsp;" + word
+    deferred_count = count_deferred_todos(todos_parent)
+    if count == 0 && deferred_count > 0
+      word = deferred_count == 1 ? string.singularize : string.pluralize
+      word = "deferred&nbsp;" + word
+      deferred_count.to_s + "&nbsp;" + word
+    else
+      word = count == 1 ? string.singularize : string.pluralize
+      count.to_s + "&nbsp;" + word
+    end
   end
 
   def count_undone_todos(todos_parent)
@@ -104,6 +111,14 @@ class ApplicationController < ActionController::Base
       count = eval "@#{todos_parent.class.to_s.downcase}_not_done_counts[#{todos_parent.id}]"
     end
     count || 0
+  end
+
+  def count_deferred_todos(todos_parent)
+    if todos_parent.nil?
+      count = 0
+    else
+      count = todos_parent.todos.deferred.count
+    end
   end
 
   # Convert a date object to the format specified in the user's preferences in

--- a/features/project_list.feature
+++ b/features/project_list.feature
@@ -116,25 +116,25 @@ Feature: Manage the list of projects
     And the badge should show 4
     And the project list badge for "active" projects should show 4
 
-  @selenium @wip
+  @selenium
   Scenario: Listing projects with only active actions
     Given I have a project "do it now" with 2 active todos
     When I go to the projects page
     Then the project "do it now" should have 2 actions listed
 
-  @selenium @wip
+  @selenium
   Scenario: Listing projects with both active and deferred actions
     Given I have a project "now and later" with 2 active actions and 2 deferred actions
     When I go to the projects page
     Then the project "now and later" should have 2 actions listed
 
-  @selenium @wip
+  @selenium
   Scenario: Listing projects with only deferred actions
     Given I have a project "only later" with 3 deferred actions
     When I go to the projects page
     Then the project "only later" should have 3 deferred actions listed
 
-  @selenium @wip
+  @selenium
   Scenario: Listing projects with no actions
     Given I have a project "all done" with 0 active actions and 0 deferred actions
     When I go to the projects page


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #45](https://www.assembla.com/spaces/tracks-tickets/tickets/45), now #1512._

Fixes ticket #1084 according to what the reporter asked for. Change the message to say "y deferred actions" if there are no active actions.
