### PR TITLE
Keep hidden projects from showing up as stalled

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -121,7 +121,7 @@ class Project < ActiveRecord::Base
 
   def stalled?
     # stalled is active/hidden project with no active todos
-    return false if self.completed?
+    return false if self.completed? || self.hidden?
     return self.todos.deferred_or_blocked.empty? && self.todos.not_deferred_or_blocked.empty?
   end
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #55](https://www.assembla.com/spaces/tracks-tickets/tickets/55), now #1522._

Projects that are hidden are likely not stalled, just removed from view (use-case that I'm thinking of is for using the hidden context as a sort of Someday / Maybe for projects).
