### PR TITLE
Mobile interface layout tweaks

### DIFF
--- a/app/views/layouts/mobile.m.erb
+++ b/app/views/layouts/mobile.m.erb
@@ -12,26 +12,20 @@
 <title><%= @page_title %></title>
 </head><body>
 <% if current_user && !current_user.prefs.nil? -%>
-<div id="topbar"><h1><% if @down_count -%><span class="count" id="badge_count"><%= @down_count %></span><% end -%> <%=
-        l(Date.today, :format => current_user.prefs.title_date_format) -%></h1>
+<div id="topbar">
 <div class="nav">
-<%=     (link_to(t('layouts.mobile_navigation.new_action'), new_todo_path(new_todo_params))+" | ") unless @new_mobile -%>
-<%=     (link_to(t('layouts.mobile_navigation.home'), todos_path(:format => 'm'))+" | ") unless @home -%>
-<%=     (link_to(t('layouts.mobile_navigation.contexts'), contexts_path(:format => 'm'))+" | ") -%>
-<%=     (link_to(t('layouts.mobile_navigation.projects'), projects_path(:format => 'm'))+" | ") -%>
+<%=     (link_to(t('layouts.mobile_navigation.new_action'), new_todo_path(new_todo_params))) unless @new_mobile -%>
+<%=     (link_to(t('layouts.mobile_navigation.home'), todos_path(:format => 'm'))) unless @home -%>
+<%=     (link_to(t('layouts.mobile_navigation.contexts'), contexts_path(:format => 'm'))) -%>
+<%=     (link_to(t('layouts.mobile_navigation.projects'), projects_path(:format => 'm'))) -%>
 <%=     (link_to(t('layouts.mobile_navigation.starred'), {:action => "tag", :controller => "todos", :id => "starred.m"})) -%>
 <% end -%>
 </div></div>
 <div id="content"><%= render_flash -%><%=  yield -%></div>
 <hr/><% if current_user && !current_user.prefs.nil? -%>
 <div class="nav">
-<%= (link_to(t('layouts.mobile_navigation.logout'), logout_path(:format => 'm')) +" | ") -%>
-<%= (link_to(t('layouts.mobile_navigation.new_action'), new_todo_path(new_todo_params), {:accesskey => "0"})+" | ") unless @new_mobile -%>
-<%= (link_to(t('layouts.mobile_navigation.home'), todos_path(:format => 'm'), {:accesskey => "1"})+" | ") unless @home -%>
-<%= (link_to(t('layouts.mobile_navigation.contexts'), contexts_path(:format => 'm'), {:accesskey => "2"})+" | ") -%>
-<%= (link_to(t('layouts.mobile_navigation.projects'), projects_path(:format => 'm'), {:accesskey => "3"})+" | ") -%>
-<%= (link_to(t('layouts.mobile_navigation.starred'), {:action => "tag", :controller => "todos", :id => "starred.m"}, {:accesskey => "4"})+" | ") -%>
-<%= (link_to(t('layouts.mobile_navigation.tickler'), {:action => "index", :controller => "tickler.m"})+" | ") -%>
+<%= (link_to(t('layouts.mobile_navigation.logout'), logout_path(:format => 'm'))) -%>
+<%= (link_to(t('layouts.mobile_navigation.tickler'), {:action => "index", :controller => "tickler.m"})) -%>
 <%= (link_to(t('layouts.mobile_navigation.feeds'), {:action => "index", :controller => "feeds.m"})) -%>
 </div>
 <% end -%>

--- a/public/stylesheets/mobile.css
+++ b/public/stylesheets/mobile.css
@@ -4,7 +4,7 @@ body {
 }
 
 #content {
-    margin-top: 50px;
+    margin-top: 4em;
 }
 
 div.footer {
@@ -178,9 +178,7 @@ span.r {
     background-color: #000000;
     clear: both;
     color: #EEEEEE;
-    height: 45px;
     left: 0;
-    margin-bottom: 5px;
     position: fixed;
     top: 0;
     width: 100%;
@@ -190,19 +188,15 @@ span.r {
 .nav {
   color: #fff;
   background: #000;
-  padding-top: 0.2em;
-  padding-bottom: 0.2em;
-}
-
-#topbar .nav {
-  padding-left:8px;
-  margin-bottom:0.3em;
+  padding-top: 0.75em;
+  padding-bottom: 0.75em;
 }
 
 .nav a, .nav a:link, .nav a:active, .nav a:visited {
+    background: #666;
     color: #fff;
-    padding-top: 1.0em;
-    padding-bottom: 0.5em;
+    padding: 0.5em;
+    margin-left:0.5em;
 }
 
 .nav a:focus, .nav a:hover, .nav a:active {
@@ -221,6 +215,7 @@ span.r {
 table.c {
       margin-left: 5px;
 }
+
 .mobile-done {
   display:inline;
 }


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #64](https://www.assembla.com/spaces/tracks-tickets/tickets/64), now #1531._

  removing count and date as space is at a premium and not essential
  making menu padding larger to provide more space to click
  removing duplicated menus to stop wrapping
  Increasing the top margin above the content div to reduce fat fingers from clicking links in the content instead of the intended nav links
  Cleaning up some unused selectors and consistent spacing, etc...
