### PR TITLE
Fix: the context view doesn't show pending or due todos

### DIFF
--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -277,7 +277,7 @@ class ContextsController < ApplicationController
       # search manually until I can work out a way to do the same thing using
       # not_done_todos acts_as_todo_container method Hides actions in hidden
       # projects from context.
-      @not_done_todos = @context.todos.active(
+      @not_done_todos = @context.todos.not_completed(
         :order => "todos.due IS NULL, todos.due ASC, todos.created_at ASC",
         :include => Todo::DEFAULT_INCLUDES)
 

--- a/features/context_list.feature
+++ b/features/context_list.feature
@@ -27,6 +27,15 @@ Feature: Manage the list of contexts
     And I follow "@computer"
     Then I should be on the context page for "@computer"
 
+  Scenario: The context view shows all todos
+    Given I have a todo "foo" in the context "@bar" which is due tomorrow
+    Given I have a deferred todo "foo2" in the context "@bar"
+    Given I have a todo "foo3" in the context "@bar"
+    When I go to the contexts page
+    And I follow "@bar"
+    Then I should be on the context page for "@bar"
+    And the badge should show 3
+
   @selenium
   Scenario: Delete context from context page should update badge
     Given I have a context called "@computer"


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #67](https://www.assembla.com/spaces/tracks-tickets/tickets/67), now #1534._

Currently the admin page for contexts only shows active and done todos. This means that pending ones fall through the cracks.
- Cucumber works.
- Added a new test for the correct behaviour.
