### PR TITLE
Add !important to ui-datepicker z-index declaration.

### DIFF
--- a/public/stylesheets/standard.css
+++ b/public/stylesheets/standard.css
@@ -1419,7 +1419,7 @@ div.auto_complete ul strong.highlight {
 }
 
 .ui-datepicker {
-  z-index: 1000;
+  z-index: 1000 !important;
 }
 
 .ui-autocomplete-loading {


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #70](https://www.assembla.com/spaces/tracks-tickets/tickets/70), now #1537._

Fix closed bug #1013 on Assembla. The previous z-index was well
intentioned but jquery css overrides the z-index, so !important is
necessary to make the z-index declaration functional.
