### PR TITLE
Fix for #1254 - days shows as rational number instead of integer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
   end
   
   def days_from_today(date)
-    date.in_time_zone.to_date - current_user.time.to_date
+    Integer (date.in_time_zone.to_date - current_user.time.to_date)
   end
   
   # Check due date in comparison to today's date Flag up date appropriately with


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #76](https://www.assembla.com/spaces/tracks-tickets/tickets/76), now #1543._

I had to update my ruby (because of another app I use) to ruby 1.9.2 and the due_date labels where showing "overdue by x/1 days" instead of "overdue by x days".  This commit fixes that one.
