### PR TITLE
#1289 - tweak for project page note display to stop wrapping note around link icon

### DIFF
--- a/app/views/notes/_notes_summary.rhtml
+++ b/app/views/notes/_notes_summary.rhtml
@@ -1,11 +1,12 @@
 <% note = notes_summary -%>
 <div class="note_wrapper" id="<%= dom_id(note) %>">
+<div class="note_link">
 <%= link_to( 
   image_tag("blank.png", :border => 0),
   note,
   :title => t('notes.show_note_title'),
   :class => "link_to_notes icon",
-  :id => dom_id(note, "link")) %>&nbsp;
-<%= rendered_note(note) %>
+  :id => dom_id(note, "link")) %></div>
+<div class="note_note"><%= rendered_note(note) %></div>
 </div>
 <% note = nil -%>

--- a/public/stylesheets/standard.css
+++ b/public/stylesheets/standard.css
@@ -550,6 +550,10 @@ div.note_wrapper p {
     display: inline;
 }
 
+div.note_note {
+    margin-left:24px;
+}
+
 div.note_footer {
     border-top: 1px solid #999;
     padding-top: 3px;


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #79](https://www.assembla.com/spaces/tracks-tickets/tickets/79), now #1546._

divs for the project note
adding margin to prevent the note from wrapping around the link icon
