### PR TITLE
Fix for #1291 - Adding todo to mobile interface does not save tag

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1424,8 +1424,8 @@ class TodosController < ApplicationController
   end
 
   def update_tags
-    if params[:tag_list]
-      @todo.tag_with(params[:tag_list])
+    if params[:todo_tag_list]
+      @todo.tag_with(params[:todo_tag_list])
       @todo.tags(true) #force a reload for proper rendering
     end
   end

--- a/app/views/todos/_edit_form.rhtml
+++ b/app/views/todos/_edit_form.rhtml
@@ -23,8 +23,8 @@ form_for(todo, :html=> { :name=>'todo', :id => dom_id(@todo, 'form'), :class => 
     <input id="<%= dom_id(@todo, 'context_name') %>" name="context_name" autocomplete="off" tabindex="<%= next_tab_index%>" size="30" type="text" value="<%= h @todo.context.name %>" />
   </div>
 
-  <label class="tag_list_label" for="<%= dom_id(@todo, 'tag_list') %>"><%= t('todos.tags') %></label>
-  <%= text_field_tag 'tag_list', tag_list_text, :id => dom_id(@todo, 'tag_list'), :size => 30, :tabindex => next_tab_index %>
+  <label class="tag_list_label" for="<%= dom_id(@todo, 'todo_tag_list') %>"><%= t('todos.tags') %></label>
+  <%= text_field_tag 'todo_tag_list', tag_list_text, :id => dom_id(@todo, 'todo_tag_list'), :size => 30, :tabindex => next_tab_index %>
 
   <div class="due_input">
     <label for="<%= dom_id(@todo, 'due_label') %>"><%= Todo.human_attribute_name('due') %></label>

--- a/app/views/todos/_edit_mobile_form.rhtml
+++ b/app/views/todos/_edit_mobile_form.rhtml
@@ -6,8 +6,8 @@
 <% this_year = current_user.time.to_date.strftime("%Y").to_i -%>
 <h2><label for="todo_description"><%= t('common.description') %></label></h2>
 <%= text_field( "todo", "description", "tabindex" => 1, "maxlength" => 100, "size" => 50) %>
-<h2><label for="tag_list"><%= t('todos.tags') %></label></h2>
-<%= text_field_tag "tag_list", @tag_list_text, :size => 50, :tabindex => 2 %>
+<h2><label for="todo_tag_list"><%= t('todos.tags') %></label></h2>
+<%= text_field_tag "todo_tag_list", @tag_list_text, :size => 50, :tabindex => 2 %>
 <h2><label for="todo_context_id"><%= t('common.context') %></label></h2>
 <%= unless @mobile_from_context
   collection_select( "todo", "context_id", @contexts, "id", "name", {}, {"tabindex" => 3} )

--- a/public/stylesheets/mobile.css
+++ b/public/stylesheets/mobile.css
@@ -230,7 +230,7 @@ table.c {
   display:inline;
 }
 
-input#todo_description, input#tag_list, textarea#todo_notes, select#todo_project_id, select#todo_context_id {
+input#todo_description, input#todo_tag_list, textarea#todo_notes, select#todo_project_id, select#todo_context_id {
   width: 95%;
 }
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #80](https://www.assembla.com/spaces/tracks-tickets/tickets/80), now #1547._

the mobile interface shares the form for creating and updating todos.
the todo controller was using different names for them. this change
aligns them to fix the bug.
