### PR TITLE
Fix rendered notes migration

### DIFF
--- a/db/migrate/20120412072508_add_rendered_notes.rb
+++ b/db/migrate/20120412072508_add_rendered_notes.rb
@@ -9,11 +9,7 @@ class AddRenderedNotes < ActiveRecord::Migration
     # Call save! on each todo to force generation of rendered_todos
     i=0; max = Todo.all.count; start = Time.now
     Todo.all.each do |todo|
-      if Rails.version < '3.0'
-        todo.save(false)
-      else
-        todo.save(:validate => false)
-      end
+      todo.save(:validate => false)
       i = i + 1
       if i%250==0
         elapsed_sec = (Time.now-start)


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #87](https://www.assembla.com/spaces/tracks-tickets/tickets/87), now #1554._

Rails 3.1+ doesn't support `save(bool)` anymore so the AddRenderedNotes migration failed when I upgraded.
