### PR TITLE
Disabled autocomplete on new password field

### DIFF
--- a/app/views/users/_update_password.html.erb
+++ b/app/views/users/_update_password.html.erb
@@ -1,4 +1,4 @@
 <label for="user[password]"><%= t('users.new_password_label') %>:</label><br/>
-<%= password_field "user", "password", :size => 40 %><br/>
+<%= password_field "user", "password", :size => 40, :autocomplete => "off" %><br/>
 <label for="user[password_confirmation]"><%= t('users.password_confirmation_label') %>:</label><br/>
-<%= password_field "user", "password_confirmation", :size => 40 %><br/>
+<%= password_field "user", "password_confirmation", :size => 40, :autocomplete => "off" %><br/>


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #88](https://www.assembla.com/spaces/tracks-tickets/tickets/88), now #1555._

Chromium auto filled the new password input and it was not obvious because it is in another tab. I disabled auto complete.
