### PR TITLE
English selenium

### DIFF
--- a/features/support/tracks_cucumber_settings.rb
+++ b/features/support/tracks_cucumber_settings.rb
@@ -11,3 +11,12 @@ Capybara.javascript_driver = ENV["JS_DRIVER"] ? ENV["JS_DRIVER"].to_sym : :selen
 if Capybara.javascript_driver == :webkit
   require 'capybara/webkit'
 end
+
+if Capybara.javascript_driver == :selenium
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  profile['intl.accept_languages'] = 'en'
+  Capybara.register_driver :selenium_english do |app|
+    Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => profile)
+  end
+  Capybara.javascript_driver = :selenium_english
+end


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #93](https://www.assembla.com/spaces/tracks-tickets/tickets/93), now #1560._

My Firefox is configured with a non-English preferred language so the cucumber features fail to find the "Sign in" button.
The driver now uses a profile with a the preferred language forced to "en".
