### PR TITLE
Fixed indentation in menu

### DIFF
--- a/app/assets/stylesheets/tracks.css
+++ b/app/assets/stylesheets/tracks.css
@@ -1430,3 +1430,14 @@ div.auto_complete ul strong.highlight {
 .ui-autocomplete-loading {
   background: white url('/assets/ui-anim_basic_16x16.gif') right center no-repeat;
 }
+
+ul.todo-submenu > li > a {
+  position: relative;
+  padding-left: 24px;
+}
+
+ul.todo-submenu > li > a > img {
+  position: absolute;
+  left: 0px;
+  top: 0px;
+}

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -14,7 +14,7 @@ parameters += "&_tag_name=#{@tag_name}" if @source_view == 'tag'
     <%= remote_edit_button(todo) unless suppress_edit_button %>
     <ul class="sf-menu sf-item-menu">
       <li style="z-index:<%=@z_index_counter%>"><%= image_tag "downarrow.png", :class => "todo-submenu", :alt=> "" %>
-        <ul id="ul<%= dom_id(todo) %>">
+        <ul id="ul<%= dom_id(todo) %>" class="todo-submenu">
           <li><%= remote_delete_menu_item(todo) %></li>
           <% unless todo.completed? || todo.deferred? -%>
             <li><%= remote_defer_menu_item(1, todo) %></li>


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #94](https://www.assembla.com/spaces/tracks-tickets/tickets/94), now #1561._

The todo sub menu doesn't indent texts properly when they are on two lines. The second line starts aligned with the icon, whereas it should be aligned with the first line.

It currently doesn't happen in english, but it happens in some other languages.
