### PR TITLE
update project-meta links in README and CHANGELOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 * Project homepage: http://getontracks.org/
 * Manual: http://getontracks.org/manual/
-* Source at GitHub: http://github.com/TracksApp/tracks/
-* Assembla space (for bug reports and feature requests): http://www.assembla.com/spaces/tracks-tickets/tickets
+* Source at GitHub: https://github.com/TracksApp/tracks
+* Assembla space (for bug reports and feature requests): https://www.assembla.com/spaces/tracks-tickets/tickets
 * Wiki (community contributed information): https://github.com/TracksApp/tracks/wiki
 * Forum (read-only): http://getontracks.org/forums/
-* Mailing list: http://lists.rousette.org.uk/mailman/listinfo/tracks-discuss
+* Mailing list: http://groups.google.com/group/TracksApp
 * Original developer: bsag (http://www.rousette.org.uk/)
 * Contributors: https://github.com/TracksApp/tracks/wiki/Contributors
 * Version: 2.2devel

--- a/doc/CHANGELOG
+++ b/doc/CHANGELOG
@@ -2,11 +2,11 @@
 
 * Project homepage: http://getontracks.org/
 * Manual: http://getontracks.org/manual/
-* Source at GitHub: http://github.com/TracksApp/tracks/
-* Assembla space (for bug reports and feature requests): http://www.assembla.com/spaces/tracks-tickets/tickets
+* Source at GitHub: https://github.com/TracksApp/tracks
+* Assembla space (for bug reports and feature requests): https://www.assembla.com/spaces/tracks-tickets/tickets
 * Wiki (community contributed information): https://github.com/TracksApp/tracks/wiki
 * Forum (read-only): http://getontracks.org/forums/
-* Mailing list: http://lists.rousette.org.uk/mailman/listinfo/tracks-discuss
+* Mailing list: http://groups.google.com/group/TracksApp
 * Original developer: bsag (http://www.rousette.org.uk/)
 * Contributors: https://github.com/TracksApp/tracks/wiki/Contributors
 * Version: 2.2devel


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #97](https://www.assembla.com/spaces/tracks-tickets/tickets/97), now #1564._

Updated mailing-list link to point to new Google Group. Also changed GitHub and Assembla links to https:// since they are both SSL-only.
