### PR TITLE
mobile.css was missing from production assets precompilation list.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Tracksapp::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  config.assets.precompile += %w( print.css scaffold.css )
+  config.assets.precompile += %w( print.css scaffold.css mobile.css )
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #98](https://www.assembla.com/spaces/tracks-tickets/tickets/98), now #1565._

While setting up tracks I noticed the mobile version wasn't working in production mode because the mobile.css was missing from the asset precompilation list. This pull adds it.

tracks.css is also missing from the list but since I couldn't even see where that is used I didn't add it.
