### PR TITLE
Add favicon/apple-touch-icon to all layouts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
+  <%= favicon_link_tag 'favicon.ico' %>
+  <%= favicon_link_tag 'apple-touch-icon.png', :rel => 'apple-touch-icon', :type => 'image/png' %>
 </head>
 <body>
 

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -3,7 +3,8 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <%= stylesheet_link_tag "scaffold" %>
-
+  <%= favicon_link_tag 'favicon.ico' %>
+  <%= favicon_link_tag 'apple-touch-icon.png', :rel => 'apple-touch-icon', :type => 'image/png' %>
 <title><%= @page_title -%></title>
 
 </head>

--- a/app/views/layouts/mobile.m.erb
+++ b/app/views/layouts/mobile.m.erb
@@ -6,10 +6,12 @@
 <!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.0//EN" "http://www.wapforum.org/DTD/xhtml-mobile10.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="viewport" content="width=device-width, user-scalable=no">
-<%= stylesheet_link_tag "mobile", :media => 'handheld,all' %>
-<title><%= @page_title %></title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <%= stylesheet_link_tag "mobile", :media => 'handheld,all' %>
+  <%= favicon_link_tag 'favicon.ico' %>
+  <%= favicon_link_tag 'apple-touch-icon.png', :rel => 'apple-touch-icon', :type => 'image/png' %>
+  <title><%= @page_title %></title>
 </head><body>
 <% if current_user && !current_user.prefs.nil? -%>
 <div id="topbar"><h1><% if @down_count -%><span class="count" id="badge_count"><%= @down_count %></span><% end -%> <%=

--- a/app/views/layouts/scaffold.html.erb
+++ b/app/views/layouts/scaffold.html.erb
@@ -3,6 +3,8 @@
 <head>
   <title>Login</title>
   <%= stylesheet_link_tag "scaffold" %>
+  <%= favicon_link_tag 'favicon.ico' %>
+  <%= favicon_link_tag 'apple-touch-icon.png', :rel => 'apple-touch-icon', :type => 'image/png' %>
 </head>
 <body>
 <%= yield %>

--- a/app/views/layouts/standard.html.erb
+++ b/app/views/layouts/standard.html.erb
@@ -24,7 +24,8 @@
       setup_periodic_check("<%=check_deferred_todos_path(:format => 'js')%>", 10*60, 'POST');
       <%= generate_i18n_strings %>
     </script>
-    <link rel="shortcut icon" href="<%= image_path ('favicon.ico') %>" />
+    <%= favicon_link_tag 'favicon.ico' %>
+    <%= favicon_link_tag 'apple-touch-icon.png', :rel => 'apple-touch-icon', :type => 'image/png' %>
     <%= auto_discovery_link_tag(:rss, {:controller => "todos", :action => "index", :format => 'rss', :token => "#{current_user.token}"}, {:title => t('layouts.next_actions_rss_feed')}) %>
     <link rel="search" type="application/opensearchdescription+xml" title="Tracks" href="<%= search_plugin_path(:format => :xml) %>" />
     <title><%= @page_title %></title>


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #99](https://www.assembla.com/spaces/tracks-tickets/tickets/99), now #1566._

The apple-touch-icon asset wasn't linked anywhere and most layouts, most importantly login and mobile, also lacked the basic favicon link.

This pull adds a favicon_link_tags for both to every layout.

Are the layouts besides standard, login and mobile actually used?
