### PR TITLE
Don't sort todos when counting them

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -280,14 +280,14 @@ class ApplicationController < ActionController::Base
 
   def init_not_done_counts(parents = ['project','context'])
     parents.each do |parent|
-      eval("@#{parent}_not_done_counts ||= current_user.todos.active.group('#{parent}_id').count")
-      eval("@#{parent}_deferred_counts ||= current_user.todos.deferred.group('#{parent}_id').count")
+      eval("@#{parent}_not_done_counts ||= current_user.todos.active.count_by_group('#{parent}_id')")
+      eval("@#{parent}_deferred_counts ||= current_user.todos.deferred.count_by_group('#{parent}_id')")
     end
   end
 
   def init_project_hidden_todo_counts(parents = ['project','context'])
     parents.each do |parent|
-      eval("@#{parent}_project_hidden_todo_counts = @#{parent}_project_hidden_todo_counts || current_user.todos.count(:conditions => ['state = ? or state = ?', 'project_hidden', 'active'], :group => :#{parent}_id)")
+      eval("@#{parent}_project_hidden_todo_counts ||= current_user.todos.active_or_hidden.count_by_group('#{parent}_id')")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,11 @@ class User < ActiveRecord::Base
             end
   has_many :todos,
            :order => 'todos.completed_at DESC, todos.created_at DESC',
-           :dependent => :delete_all
+           :dependent => :delete_all do
+              def count_by_group(g)
+                except(:order).group(g).count
+              end
+           end
   has_many :recurring_todos,
            :order => 'recurring_todos.completed_at DESC, recurring_todos.created_at DESC',
            :dependent => :delete_all


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #112](https://www.assembla.com/spaces/tracks-tickets/tickets/112), now #1579._

Grouping isn't as lax in PostgreSQL as it is in MySQL or SQLite. All
sort fields also need to be in the GROUP BY, or be aggregated. The order
isn't relevant when counting, so simply don't order in that case.

Fix #1336
