### PR TITLE
Mobile task creation redirected to non-mobile results page.

### DIFF
--- a/app/views/todos/new.m.erb
+++ b/app/views/todos/new.m.erb
@@ -1,4 +1,4 @@
-<%= form_tag todos_path, :method => :post do %>
+<%= form_tag todos_path(:format => 'm'), :method => :post do %>
   <%= render :partial => 'edit_form' %>
   <p><input type="submit" value="<%= t('common.create') %>" tabindex="12" accesskey="#" /></p>
 <% end -%>


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #113](https://www.assembla.com/spaces/tracks-tickets/tickets/113), now #1580._

Creating a new task on the mobile page redirected to non-mobile results page.
