### PR TITLE
Disable loading of the full environment during assets:precompile

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,9 @@ module Tracksapp
     # Enable the asset pipeline
     config.assets.enabled = true
 
+    # Disable loading of the full environment when precompiling assets
+    config.assets.initialize_on_precompile = false
+
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
     


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #121](https://www.assembla.com/spaces/tracks-tickets/tickets/121), now #1588._

Fixes [#1338](https://www.assembla.com/spaces/tracks-tickets/tickets/1338)
