### PR TITLE
Eliminating unneeded blank space character from show_date_tag

### DIFF
--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -188,7 +188,7 @@ module TodosHelper
 
   def show_date_tag(date, the_class, text)
     content_tag(:a, :title => format_date(date)) do
-      content_tag(:span, :class => the_class) { text + " "}
+      content_tag(:span, :class => the_class) { text }
     end
   end
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #125](https://www.assembla.com/spaces/tracks-tickets/tickets/125), now #1592._

The space character causes the 'Show in x period' background color to
run into the todo description.

Closes #1368
