### PR TITLE
Remove tab-indexes for recurring todo form

### DIFF
--- a/app/views/recurring_todos/_edit_form.html.erb
+++ b/app/views/recurring_todos/_edit_form.html.erb
@@ -5,91 +5,91 @@
   <div id="recurring_todo_form_container">
     <div id="recurring_todo">
       <label for="recurring_todo_description"><%= Todo.human_attribute_name('description') %></label><%=
-      text_field_tag( "recurring_todo[description]", @recurring_todo.description, "size" => 30, "tabindex" => next_tab_index, "maxlength" => 100, :id => "edit_recurring_todo_description") -%>
+      text_field_tag( "recurring_todo[description]", @recurring_todo.description, "size" => 30, "maxlength" => 100, :id => "edit_recurring_todo_description") -%>
 
       <label for="recurring_todo_notes"><%= Todo.human_attribute_name('notes') %></label><%=
-      text_area_tag( "recurring_todo[notes]", @recurring_todo.notes, {:cols => 29, :rows => 6, :tabindex => next_tab_index}) -%>
+      text_area_tag( "recurring_todo[notes]", @recurring_todo.notes, {:cols => 29, :rows => 6}) -%>
 
       <label for="edit_recurring_todo_project_name"><%= Todo.human_attribute_name('project') %></label>
-      <input id="edit_recurring_todo_project_name" name="project_name" autocomplete="off" tabindex="<%=next_tab_index%>" size="30" type="text" value="<%= @recurring_todo.project.nil? ? 'None' : @recurring_todo.project.name.gsub(/"/,"&quot;") %>" />
+      <input id="edit_recurring_todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="<%= @recurring_todo.project.nil? ? 'None' : @recurring_todo.project.name.gsub(/"/,"&quot;") %>" />
       <div class="page_name_auto_complete" id="edit_project_list" style="display:none"></div>
 
       <label for="edit_recurring_todo_context_name"><%= Todo.human_attribute_name('context') %></label>
-      <input id="edit_recurring_todo_context_name" name="context_name" autocomplete="off" tabindex="<%=next_tab_index%>" size="30" type="text" value="<%= @recurring_todo.context.name %>" />
+      <input id="edit_recurring_todo_context_name" name="context_name" autocomplete="off" size="30" type="text" value="<%= @recurring_todo.context.name %>" />
       <div class="page_name_auto_complete" id="edit_context_list" style="display:none"></div>
 
       <label for="edit_recurring_todo_tag_list"><%= "#{Todo.human_attribute_name('tags')} #{t('shared.separate_tags_with_commas')}"%></label>
-      <%= text_field_tag "edit_recurring_todo_tag_list", @recurring_todo.tag_list, :size => 30, :tabindex => next_tab_index -%>
+      <%= text_field_tag "edit_recurring_todo_tag_list", @recurring_todo.tag_list, :size => 30 -%>
     </div>
   </div>
   <div id="recurring_edit_period_id">
     <div id="recurring_edit_period">
       <label><%= t('todos.recurrence_period') %></label><br/>
-      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'daily', @recurring_todo.recurring_period == 'daily', {:tabindex => next_tab_index})%> <%= t('todos.recurrence.daily') %><br/>
-      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'weekly', @recurring_todo.recurring_period == 'weekly', {:tabindex => next_tab_index})%> <%= t('todos.recurrence.weekly') %><br/>
-      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'monthly', @recurring_todo.recurring_period == 'monthly', {:tabindex => next_tab_index})%> <%= t('todos.recurrence.monthly') %><br/>
-      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'yearly', @recurring_todo.recurring_period == 'yearly', {:tabindex => next_tab_index})%> <%= t('todos.recurrence.yearly') %><br/>
+      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'daily', @recurring_todo.recurring_period == 'daily')%> <%= t('todos.recurrence.daily') %><br/>
+      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'weekly', @recurring_todo.recurring_period == 'weekly')%> <%= t('todos.recurrence.weekly') %><br/>
+      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'monthly', @recurring_todo.recurring_period == 'monthly')%> <%= t('todos.recurrence.monthly') %><br/>
+      <%= radio_button_tag('recurring_edit_todo[recurring_period]', 'yearly', @recurring_todo.recurring_period == 'yearly')%> <%= t('todos.recurrence.yearly') %><br/>
     </div>
     <div id="recurring_timespan">
       <br/>
       <label for="recurring_todo[start_from]"><%= t('todos.recurrence.starts_on') %>: </label><%=
-      text_field_tag("recurring_todo_edit_start_from", format_date(@recurring_todo.start_from), "size" => 12, "class" => "Date", "tabindex" => next_tab_index, "autocomplete" => "off") %><br/>
+      text_field_tag("recurring_todo_edit_start_from", format_date(@recurring_todo.start_from), "size" => 12, "class" => "Date", "autocomplete" => "off") %><br/>
       <br/>
       <label for="recurring_todo[ends_on]"><%= t('todos.recurrence.ends_on') %>:</label><br/>
-      <%= radio_button_tag('recurring_todo[ends_on]', 'no_end_date', @recurring_todo.ends_on == 'no_end_date', {:tabindex => next_tab_index})%> <%= t('todos.recurrence.no_end_date') %><br/>
-      <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_number_of_times', @recurring_todo.ends_on == 'ends_on_number_of_times', {:tabindex => next_tab_index})%>
-      <%= raw t('todos.recurrence.ends_on_number_times', :number => text_field( :recurring_todo, :number_of_occurences, "size" => 3, "tabindex" => next_tab_index)) %><br/>
-      <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_end_date', @recurring_todo.ends_on == 'ends_on_end_date', {:tabindex => next_tab_index})%>
-      <%= raw t('todos.recurrence.ends_on_date', :date => text_field_tag('recurring_todo_edit_end_date', format_date(@recurring_todo.end_date), "size" => 12, "class" => "Date", "tabindex" => next_tab_index, "autocomplete" => "off")) %><br/>
+      <%= radio_button_tag('recurring_todo[ends_on]', 'no_end_date', @recurring_todo.ends_on == 'no_end_date')%> <%= t('todos.recurrence.no_end_date') %><br/>
+      <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_number_of_times', @recurring_todo.ends_on == 'ends_on_number_of_times')%>
+      <%= raw t('todos.recurrence.ends_on_number_times', :number => text_field( :recurring_todo, :number_of_occurences, "size" => 3)) %><br/>
+      <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_end_date', @recurring_todo.ends_on == 'ends_on_end_date')%>
+      <%= raw t('todos.recurrence.ends_on_date', :date => text_field_tag('recurring_todo_edit_end_date', format_date(@recurring_todo.end_date), "size" => 12, "class" => "Date", "autocomplete" => "off")) %><br/>
     </div></div>
   <div id="recurring_edit_daily" style="display:<%= @recurring_todo.recurring_period == 'daily' ? 'block' : 'none' %> ">
     <label><%= t('todos.recurrence.daily_options') %></label><br/>
-    <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_x_day', !@recurring_todo.only_work_days, {:tabindex => next_tab_index})%>
-    <%= raw t('todos.recurrence.daily_every_number_day', :number=> text_field_tag( 'recurring_todo[daily_every_x_days]', @recurring_todo.daily_every_x_days, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
-    <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_work_day', @recurring_todo.only_work_days, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.every_work_day') %><br/>
+    <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_x_day', !@recurring_todo.only_work_days)%>
+    <%= raw t('todos.recurrence.daily_every_number_day', :number=> text_field_tag( 'recurring_todo[daily_every_x_days]', @recurring_todo.daily_every_x_days, {"size" => 3})) %><br/>
+    <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_work_day', @recurring_todo.only_work_days)%> <%= t('todos.recurrence.every_work_day') %><br/>
   </div>
   <div id="recurring_edit_weekly" style="display:<%= @recurring_todo.recurring_period == 'weekly' ? 'block' : 'none' %>">
     <label><%= t('todos.recurrence.weekly_options') %></label><br/>
-    <%= raw t('todos.recurrence.weekly_every_number_week', :number => text_field_tag('recurring_todo[weekly_every_x_week]', @recurring_todo.weekly_every_x_week, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
-    <%= check_box_tag('recurring_todo[weekly_return_monday]', 'm', @recurring_todo.on_monday, {:tabindex => next_tab_index} ) %> <%= t('date.day_names')[1] %>
-    <%= check_box_tag('recurring_todo[weekly_return_tuesday]', 't', @recurring_todo.on_tuesday, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[2] %>
-    <%= check_box_tag('recurring_todo[weekly_return_wednesday]', 'w', @recurring_todo.on_wednesday, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[3] %>
-    <%= check_box_tag('recurring_todo[weekly_return_thursday]', 't', @recurring_todo.on_thursday, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[4] %><br/>
-    <%= check_box_tag('recurring_todo[weekly_return_friday]', 'f', @recurring_todo.on_friday, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[5] %>
-    <%= check_box_tag('recurring_todo[weekly_return_saturday]', 's', @recurring_todo.on_saturday, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[6] %>
-    <%= check_box_tag('recurring_todo[weekly_return_sunday]', 's', @recurring_todo.on_sunday, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[0] %><br/>
+    <%= raw t('todos.recurrence.weekly_every_number_week', :number => text_field_tag('recurring_todo[weekly_every_x_week]', @recurring_todo.weekly_every_x_week, {"size" => 3})) %><br/>
+    <%= check_box_tag('recurring_todo[weekly_return_monday]', 'm', @recurring_todo.on_monday ) %> <%= t('date.day_names')[1] %>
+    <%= check_box_tag('recurring_todo[weekly_return_tuesday]', 't', @recurring_todo.on_tuesday) %> <%= t('date.day_names')[2] %>
+    <%= check_box_tag('recurring_todo[weekly_return_wednesday]', 'w', @recurring_todo.on_wednesday) %> <%= t('date.day_names')[3] %>
+    <%= check_box_tag('recurring_todo[weekly_return_thursday]', 't', @recurring_todo.on_thursday) %> <%= t('date.day_names')[4] %><br/>
+    <%= check_box_tag('recurring_todo[weekly_return_friday]', 'f', @recurring_todo.on_friday) %> <%= t('date.day_names')[5] %>
+    <%= check_box_tag('recurring_todo[weekly_return_saturday]', 's', @recurring_todo.on_saturday) %> <%= t('date.day_names')[6] %>
+    <%= check_box_tag('recurring_todo[weekly_return_sunday]', 's', @recurring_todo.on_sunday) %> <%= t('date.day_names')[0] %><br/>
   </div>
   <div id="recurring_edit_monthly" style="display:<%= @recurring_todo.recurring_period == 'monthly' ? 'block' : 'none' %>">
     <label><%= t('todos.recurrence.monthly_options') %></label><br/>
-    <%= radio_button_tag('recurring_todo[monthly_selector]', 'monthly_every_x_day', @recurring_todo.is_monthly_every_x_day || @recurring_todo.recurring_period == 'weekly', {:tabindex => next_tab_index})%>
+    <%= radio_button_tag('recurring_todo[monthly_selector]', 'monthly_every_x_day', @recurring_todo.is_monthly_every_x_day || @recurring_todo.recurring_period == 'weekly')%>
     <%= raw t('todos.recurrence.day_x_on_every_x_month',
-            :day => text_field_tag('recurring_todo[monthly_every_x_day]', @recurring_todo.monthly_every_x_day, {"size" => 3, "tabindex" => next_tab_index}),
-            :month => text_field_tag('recurring_todo[monthly_every_x_month]', @recurring_todo.monthly_every_x_month, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
-    <%= radio_button_tag('recurring_todo[monthly_selector]', 'monthly_every_xth_day', @recurring_todo.is_monthly_every_xth_day, {:tabindex => next_tab_index})%>
+            :day => text_field_tag('recurring_todo[monthly_every_x_day]', @recurring_todo.monthly_every_x_day, {"size" => 3}),
+            :month => text_field_tag('recurring_todo[monthly_every_x_month]', @recurring_todo.monthly_every_x_month, {"size" => 3})) %><br/>
+    <%= radio_button_tag('recurring_todo[monthly_selector]', 'monthly_every_xth_day', @recurring_todo.is_monthly_every_xth_day)%>
     <%= raw t('todos.recurrence.monthly_every_xth_day',
-            :day => select_tag('recurring_todo[monthly_every_xth_day]', options_for_select(@xth_day, @xth_day[@recurring_todo.monthly_every_xth_day(1)-1][1]), {:tabindex => next_tab_index}),
-            :day_of_week => select_tag('recurring_todo[monthly_day_of_week]' , options_for_select(@days_of_week, @recurring_todo.monthly_day_of_week), {:tabindex => next_tab_index}),
-            :month => text_field_tag('recurring_todo[monthly_every_x_month2]', @recurring_todo.monthly_every_x_month2, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
+            :day => select_tag('recurring_todo[monthly_every_xth_day]', options_for_select(@xth_day, @xth_day[@recurring_todo.monthly_every_xth_day(1)-1][1])),
+            :day_of_week => select_tag('recurring_todo[monthly_day_of_week]' , options_for_select(@days_of_week, @recurring_todo.monthly_day_of_week)),
+            :month => text_field_tag('recurring_todo[monthly_every_x_month2]', @recurring_todo.monthly_every_x_month2, {"size" => 3})) %><br/>
   </div>
   <div id="recurring_edit_yearly" style="display:<%= @recurring_todo.recurring_period == 'yearly' ? 'block' : 'none' %>">
     <label><%= t('todos.recurrence.yearly_options') %></label><br/>
-    <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_x_day', @recurring_todo.recurrence_selector == 0, {:tabindex => next_tab_index})%>
+    <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_x_day', @recurring_todo.recurrence_selector == 0)%>
     <%= raw t('todos.recurrence.yearly_every_x_day',
-            :month => select_tag('recurring_todo[yearly_month_of_year]', options_for_select(@months_of_year, @recurring_todo.yearly_month_of_year), {:tabindex => next_tab_index}),
-            :day => text_field_tag('recurring_todo[yearly_every_x_day]', @recurring_todo.yearly_every_x_day, "size" => 3, "tabindex" => next_tab_index)) %><br/>
-    <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_xth_day', @recurring_todo.recurrence_selector == 1, {:tabindex => next_tab_index})%>
+            :month => select_tag('recurring_todo[yearly_month_of_year]', options_for_select(@months_of_year, @recurring_todo.yearly_month_of_year)),
+            :day => text_field_tag('recurring_todo[yearly_every_x_day]', @recurring_todo.yearly_every_x_day, "size" => 3)) %><br/>
+    <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_xth_day', @recurring_todo.recurrence_selector == 1)%>
     <%= raw t('todos.recurrence.yearly_every_xth_day',
-            :day => select_tag('recurring_todo[yearly_every_xth_day]', options_for_select(@xth_day, @recurring_todo.yearly_every_xth_day), {:tabindex => next_tab_index}),
-            :day_of_week => select_tag('recurring_todo[yearly_day_of_week]', options_for_select(@days_of_week, @recurring_todo.yearly_day_of_week), {:tabindex => next_tab_index}),
-            :month => select_tag('recurring_todo[yearly_month_of_year2]', options_for_select(@months_of_year, @recurring_todo.yearly_month_of_year2), {:tabindex => next_tab_index})) %><br/>
+            :day => select_tag('recurring_todo[yearly_every_xth_day]', options_for_select(@xth_day, @recurring_todo.yearly_every_xth_day)),
+            :day_of_week => select_tag('recurring_todo[yearly_day_of_week]', options_for_select(@days_of_week, @recurring_todo.yearly_day_of_week)),
+            :month => select_tag('recurring_todo[yearly_month_of_year2]', options_for_select(@months_of_year, @recurring_todo.yearly_month_of_year2))) %><br/>
   </div>
   <div id="recurring_target">
     <label><%= t('todos.recurrence.recurrence_on_options') %></label><br/>
-    <%= radio_button_tag('recurring_todo[recurring_target]', 'due_date', @recurring_todo.target == 'due_date', {:tabindex => next_tab_index})%> <%= t('todos.recurrence.recurrence_on_due_date') %>. <%= t('todos.recurrence.show_options') %>:
-    <%= radio_button_tag('recurring_todo[recurring_show_always]', '1', @recurring_todo.show_always?, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.show_option_always') %>
-    <%= radio_button_tag('recurring_todo[recurring_show_always]', '0', !@recurring_todo.show_always?, {:tabindex => next_tab_index})%>
-    <%= raw t('todos.recurrence.show_days_before', :days => text_field_tag( 'recurring_todo[recurring_show_days_before]', @recurring_todo.show_from_delta, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
-    <%= radio_button_tag('recurring_todo[recurring_target]', 'show_from_date', @recurring_todo.target == 'show_from_date', {:tabindex => next_tab_index})%> <%= t('todos.recurrence.from_tickler') %><br/>
+    <%= radio_button_tag('recurring_todo[recurring_target]', 'due_date', @recurring_todo.target == 'due_date')%> <%= t('todos.recurrence.recurrence_on_due_date') %>. <%= t('todos.recurrence.show_options') %>:
+    <%= radio_button_tag('recurring_todo[recurring_show_always]', '1', @recurring_todo.show_always?)%> <%= t('todos.recurrence.show_option_always') %>
+    <%= radio_button_tag('recurring_todo[recurring_show_always]', '0', !@recurring_todo.show_always?)%>
+    <%= raw t('todos.recurrence.show_days_before', :days => text_field_tag( 'recurring_todo[recurring_show_days_before]', @recurring_todo.show_from_delta, {"size" => 3})) %><br/>
+    <%= radio_button_tag('recurring_todo[recurring_target]', 'show_from_date', @recurring_todo.target == 'show_from_date')%> <%= t('todos.recurrence.from_tickler') %><br/>
     <br/>
   </div>
 <% end %>

--- a/app/views/recurring_todos/_recurring_todo_form.html.erb
+++ b/app/views/recurring_todos/_recurring_todo_form.html.erb
@@ -1,4 +1,3 @@
-<%- reset_tab_index %>
 <div class="recurring_container">
 <%= form_for(@new_recurring_todo, :html=> { :id=>'recurring-todo-form-new-action', :name=>'recurring_todo', :class => 'inline-form' }) do -%>
     <div id="error_status"><%= get_list_of_error_messages_for(@new_recurring_todo) %></div>
@@ -6,84 +5,84 @@
     <div id="recurring_todo_form_container">
       <div id="recurring_todo">
         <label for="recurring_todo_description"><%= Todo.human_attribute_name('description') %></label><%=
-        text_field_tag( "recurring_todo[description]", "", "size" => 30, "tabindex" => next_tab_index, "maxlength" => 100) -%>
+        text_field_tag( "recurring_todo[description]", "", "size" => 30, "maxlength" => 100) -%>
         <label for="recurring_todo_notes"><%= Todo.human_attribute_name('notes') %></label><%=
-        text_area_tag( "recurring_todo[notes]", nil, {:cols => 29, :rows => 6, :tabindex => next_tab_index}) -%>
+        text_area_tag( "recurring_todo[notes]", nil, {:cols => 29, :rows => 6}) -%>
         <label for="recurring_todo_project_name"><%= Todo.human_attribute_name('project') %></label>
-        <input id="recurring_todo_project_name" name="project_name" autocomplete="off" tabindex="<%=next_tab_index%>" size="30" type="text" value="" />
+        <input id="recurring_todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="" />
         <div class="page_name_auto_complete" id="project_list" style="display:none"></div>
 
         <label for="recurring_todo_context_name"><%= Todo.human_attribute_name('context') %></label>
-        <input id="recurring_todo_context_name" name="context_name" autocomplete="off" tabindex="<%=next_tab_index%>" size="30" type="text" value="<%= current_user.contexts.first.name unless current_user.contexts.first.nil?%>" />
+        <input id="recurring_todo_context_name" name="context_name" autocomplete="off" size="30" type="text" value="<%= current_user.contexts.first.name unless current_user.contexts.first.nil?%>" />
         <div class="page_name_auto_complete" id="context_list" style="display:none"></div>
         <label for="tag_list"><%= "#{Todo.human_attribute_name('tags')} #{t('shared.separate_tags_with_commas')}"%></label>
-        <%= text_field_tag "tag_list", nil, :size => 30, :tabindex => next_tab_index -%>
+        <%= text_field_tag "tag_list", nil, :size => 30 -%>
       </div>
     </div>
     <div id="recurring_period_id">
       <div id="recurring_period">
         <label><%= t('todos.recurrence_period') %></label><br/>
-        <%= radio_button_tag('recurring_todo[recurring_period]', 'daily', true, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.daily') %><br/>
-        <%= radio_button_tag('recurring_todo[recurring_period]', 'weekly', false, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.weekly') %><br/>
-        <%= radio_button_tag('recurring_todo[recurring_period]', 'monthly', false, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.monthly') %><br/>
-        <%= radio_button_tag('recurring_todo[recurring_period]', 'yearly', false, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.yearly') %><br/>
+        <%= radio_button_tag('recurring_todo[recurring_period]', 'daily', true)%> <%= t('todos.recurrence.daily') %><br/>
+        <%= radio_button_tag('recurring_todo[recurring_period]', 'weekly', false)%> <%= t('todos.recurrence.weekly') %><br/>
+        <%= radio_button_tag('recurring_todo[recurring_period]', 'monthly', false)%> <%= t('todos.recurrence.monthly') %><br/>
+        <%= radio_button_tag('recurring_todo[recurring_period]', 'yearly', false)%> <%= t('todos.recurrence.yearly') %><br/>
       </div>
       <div id="recurring_timespan">
         <br/>
         <label for="recurring_todo[start_from]"><%= t('todos.recurrence.starts_on') %>:</label><%=
-        text_field(:recurring_todo, :start_from, "value" => format_date(current_user.time), "size" => 12, "class" => "Date", "tabindex" => next_tab_index, "autocomplete" => "off") %><br/>
+        text_field(:recurring_todo, :start_from, "value" => format_date(current_user.time), "size" => 12, "class" => "Date", "autocomplete" => "off") %><br/>
         <br/>
         <label for="recurring_todo[ends_on]"><%= t('todos.recurrence.ends_on') %>:</label><br/>
-        <%= radio_button_tag('recurring_todo[ends_on]', 'no_end_date', true, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.no_end_date') %><br/>
-        <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_number_of_times', false, {:tabindex => next_tab_index})%> <%= raw t('todos.recurrence.ends_on_number_times', :number => text_field( :recurring_todo, :number_of_occurences, "size" => 3, "tabindex" => next_tab_index)) %> <br/>
-        <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_end_date', false, {:tabindex => next_tab_index})%> <%= raw t('todos.recurrence.ends_on_date', :date => text_field(:recurring_todo, :end_date, "size" => 12, "class" => "Date", "tabindex" => next_tab_index, "autocomplete" => "off", "value" => "")) %><br/>
+        <%= radio_button_tag('recurring_todo[ends_on]', 'no_end_date', true)%> <%= t('todos.recurrence.no_end_date') %><br/>
+        <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_number_of_times', false)%> <%= raw t('todos.recurrence.ends_on_number_times', :number => text_field( :recurring_todo, :number_of_occurences, "size" => 3)) %> <br/>
+        <%= radio_button_tag('recurring_todo[ends_on]', 'ends_on_end_date', false)%> <%= raw t('todos.recurrence.ends_on_date', :date => text_field(:recurring_todo, :end_date, "size" => 12, "class" => "Date", "autocomplete" => "off", "value" => "")) %><br/>
     </div></div>
     <div id="recurring_daily" style="display:block">
       <label><%= t('todos.recurrence.daily_options') %></label><br/>
-      <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_x_day', true, {:tabindex => next_tab_index})%> <%= raw t('todos.recurrence.daily_every_number_day', :number=> text_field_tag( 'recurring_todo[daily_every_x_days]', "1", {"size" => 3, "tabindex" => next_tab_index})) %><br/>
-      <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_work_day', false, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.every_work_day') %><br/>
+      <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_x_day', true)%> <%= raw t('todos.recurrence.daily_every_number_day', :number=> text_field_tag( 'recurring_todo[daily_every_x_days]', "1", {"size" => 3})) %><br/>
+      <%= radio_button_tag('recurring_todo[daily_selector]', 'daily_every_work_day', false)%> <%= t('todos.recurrence.every_work_day') %><br/>
     </div>
     <div id="recurring_weekly" style="display:none">
       <label><%= t('todos.recurrence.weekly_options') %></label><br/>
-      <%= raw t('todos.recurrence.weekly_every_number_week', :number => text_field_tag('recurring_todo[weekly_every_x_week]', 1, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
+      <%= raw t('todos.recurrence.weekly_every_number_week', :number => text_field_tag('recurring_todo[weekly_every_x_week]', 1, {"size" => 3})) %><br/>
       <% week_day = Time.new.wday -%>
       <%# TODO: this should ideally use the 'week starts on' preferences setting, too? %>
-      <%= check_box_tag('recurring_todo[weekly_return_monday]', 'm', week_day == 1 ? true : false, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[1] %>
-      <%= check_box_tag('recurring_todo[weekly_return_tuesday]', 't', week_day == 2 ? true : false, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[2] %>
-      <%= check_box_tag('recurring_todo[weekly_return_wednesday]', 'w', week_day == 3 ? true : false, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[3] %>
-      <%= check_box_tag('recurring_todo[weekly_return_thursday]', 't', week_day == 4 ? true : false, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[4] %>
-      <%= check_box_tag('recurring_todo[weekly_return_friday]', 'f', week_day == 5 ? true : false, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[5] %>
-      <%= check_box_tag('recurring_todo[weekly_return_saturday]', 's', week_day == 6 ? true : false, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[6] %>
-      <%= check_box_tag('recurring_todo[weekly_return_sunday]', 's', week_day == 0 ? true : false, {:tabindex => next_tab_index}) %> <%= t('date.day_names')[0] %>
+      <%= check_box_tag('recurring_todo[weekly_return_monday]', 'm', week_day == 1 ? true : false) %> <%= t('date.day_names')[1] %>
+      <%= check_box_tag('recurring_todo[weekly_return_tuesday]', 't', week_day == 2 ? true : false) %> <%= t('date.day_names')[2] %>
+      <%= check_box_tag('recurring_todo[weekly_return_wednesday]', 'w', week_day == 3 ? true : false) %> <%= t('date.day_names')[3] %>
+      <%= check_box_tag('recurring_todo[weekly_return_thursday]', 't', week_day == 4 ? true : false) %> <%= t('date.day_names')[4] %>
+      <%= check_box_tag('recurring_todo[weekly_return_friday]', 'f', week_day == 5 ? true : false) %> <%= t('date.day_names')[5] %>
+      <%= check_box_tag('recurring_todo[weekly_return_saturday]', 's', week_day == 6 ? true : false) %> <%= t('date.day_names')[6] %>
+      <%= check_box_tag('recurring_todo[weekly_return_sunday]', 's', week_day == 0 ? true : false) %> <%= t('date.day_names')[0] %>
     </div>
     <div id="recurring_monthly" style="display:none">
       <label><%= t('todos.recurrence.monthly_options') %></label><br/>
-      <%= radio_button_tag('recurring_todo[monthly_selector]', 'monthly_every_x_day', true, {:tabindex => next_tab_index})%> <%= raw t('todos.recurrence.day_x_on_every_x_month',
-            :day => text_field_tag('recurring_todo[monthly_every_x_day]', Time.zone.now.mday, {"size" => 3, "tabindex" => next_tab_index}),
-            :month => text_field_tag('recurring_todo[monthly_every_x_month]', 1, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
+      <%= radio_button_tag('recurring_todo[monthly_selector]', 'monthly_every_x_day', true)%> <%= raw t('todos.recurrence.day_x_on_every_x_month',
+            :day => text_field_tag('recurring_todo[monthly_every_x_day]', Time.zone.now.mday, {"size" => 3}),
+            :month => text_field_tag('recurring_todo[monthly_every_x_month]', 1, {"size" => 3})) %><br/>
       <%= radio_button_tag('recurring_todo[monthly_selector]', 'monthly_every_xth_day')%> <%= raw t('todos.recurrence.monthly_every_xth_day',
-            :day => select_tag('recurring_todo[monthly_every_xth_day]', options_for_select(@xth_day), {:tabindex => next_tab_index}),
-            :day_of_week => select_tag('recurring_todo[monthly_day_of_week]' , options_for_select(@days_of_week, Time.zone.now.wday), {:tabindex => next_tab_index}),
-            :month => text_field_tag('recurring_todo[monthly_every_x_month2]', 1, {"size" => 3, "tabindex" => next_tab_index})) %><br/>
+            :day => select_tag('recurring_todo[monthly_every_xth_day]', options_for_select(@xth_day)),
+            :day_of_week => select_tag('recurring_todo[monthly_day_of_week]' , options_for_select(@days_of_week, Time.zone.now.wday)),
+            :month => text_field_tag('recurring_todo[monthly_every_x_month2]', 1, {"size" => 3})) %><br/>
     </div>
     <div id="recurring_yearly" style="display:none">
       <label><%= t('todos.recurrence.yearly_options') %></label><br/>
-      <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_x_day', true, {:tabindex => next_tab_index})%> <%= raw t('todos.recurrence.yearly_every_x_day',
-      :month => select_tag('recurring_todo[yearly_month_of_year]', options_for_select(@months_of_year, Time.zone.now.month), {:tabindex => next_tab_index}),
-            :day => text_field_tag('recurring_todo[yearly_every_x_day]', Time.zone.now.day, "size" => 3, "tabindex" => next_tab_index)) %><br/>
-      <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_xth_day', false, {:tabindex => next_tab_index})%> <%= raw t('todos.recurrence.yearly_every_xth_day',
-            :day => select_tag('recurring_todo[yearly_every_xth_day]', options_for_select(@xth_day), {:tabindex => next_tab_index}),
-            :day_of_week => select_tag('recurring_todo[yearly_day_of_week]', options_for_select(@days_of_week, Time.zone.now.wday), {:tabindex => next_tab_index}),
-            :month => select_tag('recurring_todo[yearly_month_of_year2]', options_for_select(@months_of_year, Time.zone.now.month), {:tabindex => next_tab_index})) %><br/>
+      <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_x_day', true)%> <%= raw t('todos.recurrence.yearly_every_x_day',
+      :month => select_tag('recurring_todo[yearly_month_of_year]', options_for_select(@months_of_year, Time.zone.now.month)),
+            :day => text_field_tag('recurring_todo[yearly_every_x_day]', Time.zone.now.day, "size" => 3)) %><br/>
+      <%= radio_button_tag('recurring_todo[yearly_selector]', 'yearly_every_xth_day', false)%> <%= raw t('todos.recurrence.yearly_every_xth_day',
+            :day => select_tag('recurring_todo[yearly_every_xth_day]', options_for_select(@xth_day)),
+            :day_of_week => select_tag('recurring_todo[yearly_day_of_week]', options_for_select(@days_of_week, Time.zone.now.wday)),
+            :month => select_tag('recurring_todo[yearly_month_of_year2]', options_for_select(@months_of_year, Time.zone.now.month))) %><br/>
     </div>
     <div id="recurring_target">
       <label><%= t('todos.recurrence.recurrence_on_options') %></label><br/>
-      <%= radio_button_tag('recurring_todo[recurring_target]', 'due_date', true, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.recurrence_on_due_date') %>. <%= t('todos.recurrence.show_options') %>:
-        <%= radio_button_tag('recurring_todo[recurring_show_always]', '1', true, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.show_option_always') %>
-        <%= radio_button_tag('recurring_todo[recurring_show_always]', '0', false, {:tabindex => next_tab_index})%>
-          <%= raw t('todos.recurrence.show_days_before', :days => text_field_tag( 'recurring_todo[recurring_show_days_before]', "0", {"size" => 3, "tabindex" => next_tab_index})) %>
+      <%= radio_button_tag('recurring_todo[recurring_target]', 'due_date', true)%> <%= t('todos.recurrence.recurrence_on_due_date') %>. <%= t('todos.recurrence.show_options') %>:
+        <%= radio_button_tag('recurring_todo[recurring_show_always]', '1', true)%> <%= t('todos.recurrence.show_option_always') %>
+        <%= radio_button_tag('recurring_todo[recurring_show_always]', '0', false)%>
+          <%= raw t('todos.recurrence.show_days_before', :days => text_field_tag( 'recurring_todo[recurring_show_days_before]', "0", {"size" => 3})) %>
           <br/>
-      <%= radio_button_tag('recurring_todo[recurring_target]', 'show_from_date', false, {:tabindex => next_tab_index})%> <%= t('todos.recurrence.from_tickler') %><br/>
+      <%= radio_button_tag('recurring_todo[recurring_target]', 'show_from_date', false)%> <%= t('todos.recurrence.from_tickler') %><br/>
       <br/>
     </div>
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #128](https://www.assembla.com/spaces/tracks-tickets/tickets/128), now #1595._

Using the natural tab order makes the Create and Cancel buttons accessible.

Fixes [#1371](https://www.assembla.com/spaces/tracks-tickets/tickets/1371)
