### PR TITLE
Reload columns before rendering notes during migration

### DIFF
--- a/db/migrate/20120412072508_add_rendered_notes.rb
+++ b/db/migrate/20120412072508_add_rendered_notes.rb
@@ -2,6 +2,8 @@ class AddRenderedNotes < ActiveRecord::Migration
   def self.up
     add_column :todos, 'rendered_notes', :text
     
+    Todo.reset_column_information
+
     puts "-- Clearing show_from dates from completed todos"
     # clear up completed todos that have show_from set. These could have been left over from before the AASM migration
     Todo.completed.find(:all, :conditions =>[ "NOT(show_from IS NULL)"]).each {|t| t.show_from=nil; t.save!}


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #129](https://www.assembla.com/spaces/tracks-tickets/tickets/129), now #1596._

Fixes [#1351](https://www.assembla.com/spaces/tracks-tickets/tickets/1351) for 2.1 branch
