### PR TITLE
Add bin to .gitignore :+1:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tags
 /public/assets/
 .sass-cache/
 /coverage
+/bin


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #141](https://www.assembla.com/spaces/tracks-tickets/tickets/141), now #1608._

Ignore the bin directory created by `bundle install --binstubs`.
