### PR TITLE
Add bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tags
 /public/assets/
 .sass-cache/
 /coverage
+/bin


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #142](https://www.assembla.com/spaces/tracks-tickets/tickets/142), now #1609._

Ignore the bin directory created by `bundle install --binstubs`.
