### PR TITLE
Update json to 1.7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'bcrypt-ruby', '~> 2.1.4'
 gem 'htmlentities', '~> 4.3.0'
 gem "mail"
 
+gem "json", ">= 1.7.7"
+
 if RUBY_VERSION.to_f >= 1.9
 	gem "soap4r-ruby1.9"
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     htmlentities (4.3.1)
     httpclient (2.3.0.1)
     i18n (0.6.1)
-    json (1.7.5)
+    json (1.7.7)
     libwebsocket (0.1.7.1)
       addressable
       websocket


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #148](https://www.assembla.com/spaces/tracks-tickets/tickets/148), now #1615._

Older versions of the json gem had vulnerabilities discussed at https://groups.google.com/forum/#!topic/rubyonrails-security/4_YvCpLzL58/discussion . Further reading: http://www.zweitag.de/en/blog/ruby-on-rails-vulnerable-to-mass-assignment-and-sql-injection
