### PR TITLE
Find tag by lowercase name in tag test

### DIFF
--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -30,7 +30,7 @@ class TagTest < ActiveSupport::TestCase
     tag = Tag.find_or_create_by_name("UPPER")
     assert !tag.new_record?
     
-    upper = Tag.find_by_name("UPPER")
+    upper = Tag.find_by_name("upper")
     assert_not_nil upper
     assert upper.name == "upper"
   end


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #150](https://www.assembla.com/spaces/tracks-tickets/tickets/150), now #1617._

The sqlite3 database is case sensitive, so searching for 'UPPER' will result in
an empty tag, since the tag is lowercased before saving.

This doesn't make any changes to the controller where `Tag.find_by_name` is actually called with input from params, since I'm assuming that the params comes from a list provided by the app itself, unless someone is messing with the url, in which case it seems like it would be OK if the request doesn't return the expected result.

If that assumption is false let me know and I'll go ahead and look at the controller.
