### PR TITLE
Swap min/max variables in i18n translation

### DIFF
--- a/app/views/stats/_actions.html.erb
+++ b/app/views/stats/_actions.html.erb
@@ -1,5 +1,5 @@
 <p><%= t('stats.actions_avg_completion_time', :count => (@actions_avg_ttc*10).round/10.0) %>
-<%= t('stats.actions_min_max_completion_days', :min=> (@actions_max_ttc*10).round/10.0, :max => (@actions_min_ttc*10).round/10.0) %>
+<%= t('stats.actions_min_max_completion_days', :max => (@actions_max_ttc*10).round/10.0, :min => (@actions_min_ttc*10).round/10.0) %>
 <%= t('stats.actions_min_completion_time', :time => @actions_min_ttc_sec) %></p>
 
 <p><%= t('stats.actions_actions_avg_created_30days', :count => (@sum_actions_created_last30days*10.0/30.0).round/10.0 )%>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -592,7 +592,7 @@ cs:
       number_of_actions: "Počet úklolů"
     actions_lastyear_title: "Úkoly za posledních 12 měsíců"
     actions_min_completion_time: "Minimální čas k dokončení je %{time}."
-    actions_min_max_completion_days: "Maximum/minimum dní na dokončení je %{min}/%{max}."
+    actions_min_max_completion_days: "Minimum/maximum dní na dokončení je %{min}/%{max}."
     actions_selected_from_week: "Úkoly vybrané z týdne "
     click_to_return: "Klepněte %{link} pro návrat ke statistikám."
     click_to_return_link: zde

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,7 +302,7 @@ en:
     projects: Projects
     action_completion_time_title: Completion time (all completed actions)
     actions_last_year: Actions in the last years
-    actions_min_max_completion_days: The Max-/minimum days to complete is %{min}/%{max}.
+    actions_min_max_completion_days: The Min-/maximum days to complete is %{min}/%{max}.
     tags: Tags
     actions_min_completion_time: The minimum time to complete is %{time}.
     no_tags_available: no tags available

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -583,7 +583,7 @@ es:
       number_of_actions: "Number of actions"
     actions_lastyear_title: "Actions in the last 12 months"
     actions_min_completion_time: "The minimum time to complete is %{time}."
-    actions_min_max_completion_days: "The Max-/minimum days to complete is %{min}/%{max}."
+    actions_min_max_completion_days: "The Min-/maximum days to complete is %{min}/%{max}."
     actions_selected_from_week: "Actions selected from week "
     click_to_return: "Click %{link} to return to the statistics page."
     click_to_return_link: here

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -629,7 +629,7 @@ fr:
       number_of_actions: "Nombre d'actions"
     actions_lastyear_title: "Actions des 12 derniers mois"
     actions_min_completion_time: "Le temps minimum de réalisation est %{time}."
-    actions_min_max_completion_days: "Le nombre max/min de jours pour réaliser est %{min}/%{max}."
+    actions_min_max_completion_days: "Le nombre min/max de jours pour réaliser est %{min}/%{max}."
     actions_selected_from_week: "Actions selectionnées depuis la semaine"
     click_to_return: "Cliquer %{link} pour revenir à la page des statistiques"
     click_to_return_link: ici

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -635,7 +635,7 @@ nl:
       number_of_actions: "Aantal acties"
     actions_lastyear_title: "Acties in de afgelopen 12 maanden"
     actions_min_completion_time: "De minimale tijd tot afronding is %{time}."
-    actions_min_max_completion_days: "De max-/minimum dagen tot voltooiing is %{min}/%{max}."
+    actions_min_max_completion_days: "De min-/maximum dagen tot voltooiing is %{min}/%{max}."
     actions_selected_from_week: "Gekozen acties van week"
     click_to_return: "Klik %{link} om terug te keren naar de statistieken pagina."
     click_to_return_link: hier


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #156](https://www.assembla.com/spaces/tracks-tickets/tickets/156), now #1623._

The :min was pointing at the max value, and the inverse.

I had to tweak a few of the language files as well, to make sure that
minimum and maximum are pointing to the correct values.

I didn't touch the hebrew language file, so someone with the correct
language skills may want to take a look at it to make sure that the text
matches the interpolation variables that get sent in.
