### PR TITLE
Split up the font size calculation

### DIFF
--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -1,2 +1,7 @@
 module StatsHelper
+
+  def font_size(cloud, tag)
+    9 + 2 * cloud.relative_size(tag)
+  end
+
 end

--- a/app/models/stats/tag_cloud.rb
+++ b/app/models/stats/tag_cloud.rb
@@ -13,8 +13,8 @@ module Stats
       tags.empty?
     end
 
-    def font_size(tag)
-      (9 + 2*(tag.count-min)/divisor)
+    def relative_size(tag)
+      (tag.count - min) / divisor
     end
 
     private

--- a/app/views/stats/_tags.html.erb
+++ b/app/views/stats/_tags.html.erb
@@ -9,7 +9,7 @@
     tag_cloud.tags.each do |t|
 %><%=
       link_to t.name, tag_path(t.name), {
-        :style => "font-size: " + "#{tag_cloud.font_size(t)}pt",
+        :style => "font-size: " + "#{font_size(tag_cloud, t)}pt",
         :title => "#{t.count} #{t('common.actions_midsentence', :count => t.count)}"}
 -%><%
       end

--- a/test/unit/tag_cloud_test.rb
+++ b/test/unit/tag_cloud_test.rb
@@ -11,13 +11,13 @@ class TagCloudTest < Test::Unit::TestCase
     assert_equal %w(aye bee See), Stats::TagCloud.new(tags).tags.map(&:name)
   end
 
-  def test_tag_font_size
+  def test_tag_relative_size
     tags = [FakeTag.new("bee", 1), FakeTag.new("See", 10), FakeTag.new("aye", 100)]
     cloud = Stats::TagCloud.new(tags)
 
-    assert_equal 9, cloud.font_size(FakeTag.new("whatever", 1))
-    assert_equal 18, cloud.font_size(FakeTag.new("whatever", 50))
-    assert_equal 28, cloud.font_size(FakeTag.new("whatever", 100))
+    assert_equal 0, cloud.relative_size(FakeTag.new("whatever", 1))
+    assert_equal 4, cloud.relative_size(FakeTag.new("whatever", 50))
+    assert_equal 9, cloud.relative_size(FakeTag.new("whatever", 100))
   end
 
 end


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #164](https://www.assembla.com/spaces/tracks-tickets/tickets/164), now #1631._

The font size is a view concern, but the relative size belongs in the
model layer.
