### PR TITLE
Use default context sort order when returning autocomplete

### DIFF
--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -234,15 +234,7 @@ class ContextsController < ApplicationController
   
   def render_autocomplete
     lambda do
-      # find contexts and the todos count. use a join to prevent all count(todos) of each context to be fetched
-      context_and_todo_count = current_user.contexts.
-        select('contexts.*, count(todos.id) as todos_count').
-        joins('left outer join todos on context_id=contexts.id').
-        group('context_id')
-
-      filled_contexts = context_and_todo_count.reject { |ctx| ctx.todos.size == 0 } 
-      empty_contexts = context_and_todo_count.find_all { |ctx| ctx.todos.size == 0 } 
-      render :text => for_autocomplete(filled_contexts + empty_contexts, params[:term])
+      render :text => for_autocomplete(current_user.contexts, params[:term])
     end
   end
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #172](https://www.assembla.com/spaces/tracks-tickets/tickets/172), now #1639._

Fixes [#1403](https://www.assembla.com/spaces/tracks-tickets/tickets/1403) by greatly simplifying the SQL query.

I'm looking for feedback on this one. This method was doing a lot of work so that contexts with actions were ordered before empty contexts. I'm not sure why this is desirable, so I simply removed that calculation and instead return the contexts in their default sort order. Thoughts?
