### PR TITLE
Render notes using RedCloth without formatize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "sqlite3"
 gem "mysql2"
 
 gem "RedCloth"
-gem "formatize"
 gem "sanitize"
 gem "will_paginate"
 gem "acts_as_list"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,6 @@ GEM
       cucumber (>= 1.1.1)
       rspec-expectations (>= 2.7.0)
     bcrypt-ruby (3.0.1)
-    bluecloth (2.2.0)
     builder (3.0.4)
     bullet (4.3.1)
       uniform_notifier
@@ -80,10 +79,6 @@ GEM
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
     ffi (1.4.0)
-    formatize (1.1.0)
-      RedCloth (~> 4.2)
-      actionpack (~> 3.0)
-      bluecloth (~> 2.2)
     gherkin (2.11.6)
       json (>= 1.7.6)
     hike (1.2.1)
@@ -205,7 +200,6 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   factory_girl_rails
-  formatize
   htmlentities
   jquery-rails
   mocha

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -280,3 +280,7 @@ input#todo_description, input#tag_list, textarea#todo_notes, select#todo_project
         background: #cc3334 image-url('next.png') right center no-repeat;
     }
 }
+
+div.note_wrapper p {
+    display: inline;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   include LoginSystem
-  helper_method :current_user, :prefs, :format_date, :markdown
+  helper_method :current_user, :prefs, :format_date
 
   layout proc{ |controller| controller.mobile? ? "mobile" : "application" }
   # exempt_from_layout /\.js\.erb$/

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,10 +1,10 @@
 module NotesHelper
   def truncated_note(note, characters = 50)
-    sanitize(textilize_without_paragraph(truncate(note.body, :length => characters, :omission => "...")))
+    Tracks::Utils.render_text(truncate(note.body, :length => characters, :omission => "..."))
   end
 
   def rendered_note(note)
-    sanitize(textilize_without_paragraph(note.body))
+    Tracks::Utils.render_text(note.body)
   end
 
   def link_to_delete_note(note, descriptor = sanitize(note.id.to_s))

--- a/app/views/notes/_note.m.erb
+++ b/app/views/notes/_note.m.erb
@@ -1,5 +1,5 @@
 <div class="mobile_note">
-  <%= sanitize(textilize_without_paragraph(note.body)) %>
+  <%= rendered_note(note) %>
 </div>
 <div class="mobile_note_info">
   <br/>

--- a/app/views/notes/_note_details.html.erb
+++ b/app/views/notes/_note_details.html.erb
@@ -1,5 +1,5 @@
 <% note = note_details -%>
-<div class="note_boby"><%= Tracks::Utils.render_text(note.body) %></div>
+<div class="note_body"><%= rendered_note(note) %></div>
 
 <div class="note_footer">
 

--- a/app/views/notes/_notes_summary.m.erb
+++ b/app/views/notes/_notes_summary.m.erb
@@ -1,3 +1,5 @@
 <% note = notes_summary -%>
-<div class="note"><%= link_to( truncated_note(note), note_path(note, :format => 'm')) %></div>
+<div class="note_wrapper">
+  <div class="note"><%= link_to( truncated_note(note), note_path(note, :format => 'm')) %></div>
+</div>
 <% note = nil -%>

--- a/lib/tracks/utils.rb
+++ b/lib/tracks/utils.rb
@@ -22,8 +22,8 @@ module Tracks
     end
 
     def self.render_text(text)
-      rendered = Tracks::Utils.auto_link_message(text)
-      rendered = markdown(rendered)
+      rendered = auto_link_message(text)
+      rendered = textile(rendered)
       rendered = helpers.auto_link(rendered, :link => :urls)
 
       # add onenote and message protocols
@@ -34,11 +34,7 @@ module Tracks
       return rendered.html_safe
     end
     
-    # Uses RedCloth to transform text using either Textile or Markdown Need to
-    # require redcloth above RedCloth 3.0 or greater is needed to use Markdown,
-    # otherwise it only handles Textile
-    #
-    def self.markdown(text)
+    def self.textile(text)
       RedCloth.new(text).to_html
     end
     

--- a/test/functional/todos_controller_test.rb
+++ b/test/functional/todos_controller_test.rb
@@ -746,7 +746,7 @@ class TodosControllerTest < ActionController::TestCase
     assert_select("div#notes_todo_#{todo.id}", "A normal description.")
   end
   
-  def test_format_note_markdown
+  def test_format_note_textile
     login_as(:admin_user)
     todo = users(:admin_user).todos.first
     todo.notes = "A *bold description*."


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #173](https://www.assembla.com/spaces/tracks-tickets/tickets/173), now #1640._

Removes the outdated bluecloth dependency
