### PR TITLE
Add login backdoor to speed up the cucumber test suite

### DIFF
--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -1,13 +1,7 @@
 Given /^I have logged in as "(.*)" with password "(.*)"$/ do |username, password|
-  step "I go to the login page"
-  fill_in "user_login", :with => username
-  fill_in "user_password", :with => password
-  uncheck "user_noexpiry"
-  click_button "Sign in"
-  
-  logout_regexp = @mobile_interface ? "Logout" : "Logout \(#{username}\)"
-  page.should have_content(logout_regexp)
-  @current_user = User.where(:login => username).first
+  user = User.where(:login => username).first
+  request_signin_as(user)
+  @current_user = user
 end
 
 When /^I submit the login form as user "([^\"]*)" with password "([^\"]*)"$/ do |username, password|

--- a/features/support/tracks_login_helper.rb
+++ b/features/support/tracks_login_helper.rb
@@ -1,0 +1,38 @@
+class SessionBackdoorController < ::ApplicationController
+  skip_before_filter :login_required
+
+  def create
+    session['user_id'] = params[:user_id]
+    user = User.find(params[:user_id])
+    set_current_user(user)
+    user.remember_me
+    cookies[:auth_token] = { :value => user.remember_token, :expires => user.remember_token_expires_at }
+    redirect_to root_path
+  end
+end
+
+module TracksLoginHelper
+  begin
+    _routes = Rails.application.routes
+    _routes.disable_clear_and_finalize = true
+    _routes.clear!
+    Rails.application.routes_reloader.paths.each{ |path| load(path) }
+    _routes.draw do
+      # here you can add any route you want
+      match "/test_login_backdoor", to: "session_backdoor#create"
+    end
+    ActiveSupport.on_load(:action_controller) { _routes.finalize! }
+  ensure
+    _routes.disable_clear_and_finalize = false
+  end
+
+  def request_signin_as(user)
+    visit "/test_login_backdoor?user_id=#{user.id}"
+  end
+
+  def signin_as(user)
+    session[:user_id] = user.id
+    @current_user = user
+  end
+
+end

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -1,3 +1,4 @@
+World(TracksLoginHelper)
 World(TracksStepHelper)
 World(TracksFormHelper)
 World(TracksIdHelper)


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #183](https://www.assembla.com/spaces/tracks-tickets/tickets/183), now #1650._

Reduces the amount of time taken by the cucumber suite by 12% on my Retina Macbook Pro.
