### PR TITLE
Remove the badge

### DIFF
--- a/app/assets/javascripts/tracks.js
+++ b/app/assets/javascripts/tracks.js
@@ -190,9 +190,6 @@ var TracksPages = {
           show_duration = 1000;
         flash.fadeIn(fadein_duration).delay(show_duration).fadeOut(fadeout_duration);
     },
-    set_page_badge: function(count) {
-        $('#badge_count').html(count);
-    },
     setup_autocomplete_for_tag_list: function(id) {
         $(id+':not(.ac_input)')
         .bind( "keydown", function( event ) { // don't navigate away from the field on tab when selecting an item

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -275,7 +275,6 @@ class ApplicationController < ActionController::Base
     @page_title = t("#{object_name.pluralize}.all_completed_tasks_title", "#{object_name}_name".to_sym => object.name)
 
     @done = object.todos.completed.paginate :page => params[:page], :per_page => 20, :order => 'completed_at DESC', :include => Todo::DEFAULT_INCLUDES
-    @count = @done.size
     render :template => 'todos/all_done'
   end
 
@@ -286,7 +285,6 @@ class ApplicationController < ActionController::Base
     @page_title = t("#{object_name.pluralize}.completed_tasks_title", "#{object_name}_name".to_sym => object.name)
 
     @done_today, @done_rest_of_week, @done_rest_of_month = DoneTodos.done_todos_for_container(object)
-    @count = @done_today.size + @done_rest_of_week.size + @done_rest_of_month.size
 
     render :template => 'todos/done'
   end

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -8,7 +8,6 @@ class CalendarController < ApplicationController
 
     @calendar = Todos::Calendar.new(current_user)
     @projects = @calendar.projects
-    @count = current_user.todos.not_completed.are_due.count
     @due_all = current_user.todos.not_completed.are_due.reorder("due")
 
     respond_to do |format|

--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -52,8 +52,6 @@ class ContextsController < ApplicationController
 
       @projects_to_show = @projects.active
       @contexts_to_show = [@context]
-
-      @count = @not_done_todos.count + @deferred_todos.count + @pending_todos.count
       @page_title = "TRACKS::Context: #{@context.name}"
       respond_to do |format|
         format.html
@@ -185,7 +183,6 @@ class ContextsController < ApplicationController
       @active_count = @active_contexts.size
       @hidden_count = @hidden_contexts.size
       @closed_count = @closed_contexts.size
-      @count = @active_count + @hidden_count + @closed_count
       @new_context = current_user.contexts.build
 
       render

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -4,7 +4,6 @@ class NotesController < ApplicationController
 
   def index
     @all_notes = current_user.notes.all
-    @count = @all_notes.size
     @page_title = "TRACKS::All notes"
     @source_view = 'note_list'
     respond_to do |format|

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -26,7 +26,6 @@ class ProjectsController < ApplicationController
       respond_to do |format|
         format.html  do
           @page_title = t('projects.list_projects')
-          @count = current_user.projects.count
           @completed_projects = current_user.projects.completed.limit(10)
           @completed_count = current_user.projects.completed.count
           @no_projects = current_user.projects.empty?
@@ -73,7 +72,6 @@ class ProjectsController < ApplicationController
     current_user.projects.cache_note_counts
 
     @page_title = t('projects.list_reviews')
-    @count = @projects_to_review.count + @blocked_projects.count + @stalled_projects.count + @current_projects.count
 
     @no_projects = current_user.projects.empty?
     @new_project = current_user.projects.build
@@ -86,7 +84,6 @@ class ProjectsController < ApplicationController
     page = params[:page] || 1
     projects_per_page = 20
     @projects = current_user.projects.completed.paginate :page => page, :per_page => projects_per_page
-    @count = @projects.count
     @total = current_user.projects.completed.count
     @no_projects = @projects.empty?
 
@@ -140,8 +137,6 @@ class ProjectsController < ApplicationController
       limit(current_user.prefs.show_number_completed).
       includes(Todo::DEFAULT_INCLUDES) unless @max_completed == 0
 
-    @count = @not_done_todos.size
-    @down_count = @count + @deferred_todos.size + @pending_todos.size
     @next_project = current_user.projects.next_from(@project)
     @previous_project = current_user.projects.previous_from(@project)
     @default_tags = @project.default_tags

--- a/app/controllers/recurring_todos_controller.rb
+++ b/app/controllers/recurring_todos_controller.rb
@@ -14,7 +14,6 @@ class RecurringTodosController < ApplicationController
 
     @no_recurring_todos = @recurring_todos.count == 0
     @no_completed_recurring_todos = @completed_recurring_todos.count == 0
-    @count = @recurring_todos.count
 
     @new_recurring_todo = RecurringTodo.new
   end
@@ -31,7 +30,6 @@ class RecurringTodosController < ApplicationController
     items_per_page = 20
     page = params[:page] || 1
     @completed_recurring_todos = current_user.recurring_todos.completed.paginate :page => params[:page], :per_page => items_per_page
-    @total = @count = current_user.recurring_todos.completed.count
     @range_low = (page.to_i-1) * items_per_page + 1
     @range_high = @range_low + @completed_recurring_todos.size - 1
   end

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -29,8 +29,6 @@ class TodosController < ApplicationController
     respond_to do |format|
       format.html  do
         @page_title = t('todos.task_list_title')
-        # Set count badge to number of not-done, not hidden context items
-        @count = current_user.todos.active.not_hidden.count(:all)
         @todos_without_project = @not_done_todos.select{|t|t.project.nil?}
       end
       format.m do
@@ -521,7 +519,6 @@ class TodosController < ApplicationController
     @page_title = t('todos.completed_tasks_title')
 
     @done_today, @done_rest_of_week, @done_rest_of_month = DoneTodos.done_todos_for_container(current_user)
-    @count = @done_today.size + @done_rest_of_week.size + @done_rest_of_month.size
 
     respond_to do |format|
       format.html
@@ -537,7 +534,6 @@ class TodosController < ApplicationController
     @page_title = t('todos.completed_tasks_title')
 
     @done = current_user.todos.completed.includes(Todo::DEFAULT_INCLUDES).reorder('completed_at DESC').paginate :page => params[:page], :per_page => 20
-    @count = @done.size
   end
 
   def list_deferred
@@ -551,7 +547,7 @@ class TodosController < ApplicationController
 
     @not_done_todos = current_user.todos.deferred.includes(includes) + current_user.todos.pending.includes(includes)
     @todos_without_project = @not_done_todos.select{|t|t.project.nil?}
-    @down_count = @count = @not_done_todos.size
+    @down_count = @not_done_todos.size
 
     respond_to do |format|
       format.html do
@@ -634,9 +630,7 @@ class TodosController < ApplicationController
       @context = current_user.contexts.find(@not_done_todos.first.context_id)
     end
 
-    # Set count badge to number of items with this tag
-    @not_done_todos.empty? ? @count = 0 : @count = @not_done_todos.size
-    @down_count = @count
+    @down_count = @not_done_todos.size
 
     respond_to do |format|
       format.html
@@ -657,7 +651,6 @@ class TodosController < ApplicationController
     @done_today = get_done_today(completed_todos)
     @done_rest_of_week = get_done_rest_of_week(completed_todos)
     @done_rest_of_month = get_done_rest_of_month(completed_todos)
-    @count = @done_today.size + @done_rest_of_week.size + @done_rest_of_month.size
 
     render :template => 'todos/done'
   end
@@ -665,7 +658,6 @@ class TodosController < ApplicationController
   def all_done_tag
     done_by_tag_setup
     @done = current_user.todos.completed.with_tag(@tag.id).reorder('completed_at DESC').includes(Todo::DEFAULT_INCLUDES).paginate :page => params[:page], :per_page => 20
-    @count = @done.size
     render :template => 'todos/all_done'
   end
 

--- a/app/views/contexts/create.js.erb
+++ b/app/views/contexts/create.js.erb
@@ -1,7 +1,6 @@
 <% if @saved -%>
   hide_empty_message();
   TracksPages.hide_errors();
-  TracksPages.set_page_badge(<%= @down_count %>);
   add_context("<%=@context.state%>");
   clear_form();
 <% else -%>

--- a/app/views/contexts/destroy.js.erb
+++ b/app/views/contexts/destroy.js.erb
@@ -2,7 +2,6 @@ remove_deleted_context();
 
 ContextListPage.update_all_states_count(<%=@active_contexts_count%>, <%=@hidden_contexts_count%>, <%=@closed_contexts_count%>)
 
-TracksPages.set_page_badge(<%=@down_count%>);
 TracksPages.page_notify('notice', "<%=  t('contexts.context_deleted', :name=>@context.name)%>", 5);
 
 /* TODO: refactor and move function to application.js */

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,9 +39,6 @@
 
       <div id="date">
         <h1>
-          <% if @count -%>
-            <span id="badge_count" class="badge"><%= @count %></span>
-          <% end -%>
           <%= l(Date.today, :format => current_user.prefs.title_date_format) %>
         </h1>
       </div>

--- a/app/views/notes/destroy.js.erb
+++ b/app/views/notes/destroy.js.erb
@@ -1,5 +1,4 @@
 remove_deleted_note();
-TracksPages.set_page_badge(<%=@down_count%>);
 TracksPages.page_notify('notice', "<%=  t('notes.deleted_note', :id => @note.id)%>", 5);
 
 function remove_deleted_note() {

--- a/app/views/projects/create.js.erb
+++ b/app/views/projects/create.js.erb
@@ -4,7 +4,6 @@
   <% else -%>
   TracksPages.hide_errors();
   hide_empty_message();
-  TracksPages.set_page_badge(<%= @down_count %>);
   update_active_projects_container();
   add_project();
   clear_form();

--- a/app/views/projects/destroy.js.erb
+++ b/app/views/projects/destroy.js.erb
@@ -1,7 +1,6 @@
 remove_deleted_project();
 ProjectListPage.update_all_states_count(<%=@active_projects_count%>, <%=@hidden_projects_count%>, <%=@completed_projects_count%>)
 TracksPages.page_notify('notice', "Deleted project '<%= @project.name%>'", 5);
-TracksPages.set_page_badge(<%=@down_count%>);
 
 /* TODO: refactor and move function to application.js */
 function remove_deleted_project() {

--- a/app/views/recurring_todos/create.js.erb
+++ b/app/views/recurring_todos/create.js.erb
@@ -3,7 +3,6 @@
   add_recurring_todo_to_active_container();
   replace_form_with_empty_form();
   $( "#new-recurring-todo" ).dialog( "close" );
-  TracksPages.set_page_badge(<%= @down_count %>);
 <% else -%>
   TracksPages.show_errors(html_for_error_messages());
 <% end -%>

--- a/app/views/recurring_todos/toggle_check.js.erb
+++ b/app/views/recurring_todos/toggle_check.js.erb
@@ -1,5 +1,4 @@
 <%- if @saved -%>
-  TracksPages.set_page_badge(<%= @down_count %>);
   remove_old_and_add_updated_recurring_todo();
   inform_if_new_todo_created();
 <%- else -%>

--- a/app/views/todos/create.js.erb
+++ b/app/views/todos/create.js.erb
@@ -24,7 +24,6 @@
   <%= render_animation(animation) %>
   TracksPages.page_notify('notice', "<%=escape_javascript @status_message%>", 8);
   TracksPages.hide_errors();
-  TracksPages.set_page_badge(<%= @down_count %>);
 
   function clear_form(next_steps) {
     $('#todo-form-new-action').clearForm();

--- a/app/views/todos/create_multiple.js.erb
+++ b/app/views/todos/create_multiple.js.erb
@@ -18,7 +18,6 @@
   TracksPages.page_notify('notice', "<%=@status_message%>", 5);
   hide_empty_message();
   TracksPages.hide_errors();
-  TracksPages.set_page_badge(<%= @down_count %>);
   <% if should_show_new_item -%>
     <% if @new_context_created -%>
       insert_new_context_with_new_todo();

--- a/app/views/todos/destroy.js.erb
+++ b/app/views/todos/destroy.js.erb
@@ -2,7 +2,6 @@
   TracksPages.page_notify('error', "<%= t('todos.error_deleting_item', :description => @todo.description) %>", 8);
 <%- else -%>
   TracksPages.page_notify('notice', '<%=  escape_javascript(t('todos.deleted_success')) %>', 5);
-  TracksPages.set_page_badge(<%=@down_count%>);
   remove_todo_from_page();
   show_new_todo_if_todo_was_recurring();
   activate_pending_todos();

--- a/app/views/todos/toggle_check.js.erb
+++ b/app/views/todos/toggle_check.js.erb
@@ -21,7 +21,6 @@
       animation << "replace_todo"
     end -%>
     <%= render_animation(animation) %>
-    TracksPages.set_page_badge(<%= @down_count %>);
   <% end -%>
 
 function redirect_after_complete() {

--- a/app/views/todos/update.js.erb
+++ b/app/views/todos/update.js.erb
@@ -24,7 +24,6 @@
   animation << "update_predecessors"
 %>
   TracksPages.page_notify('notice', '<%=escape_javascript @status_message%>', 5);
-  TracksPages.set_page_badge(<%= @down_count %>);
   <%= render_animation(animation) %>
 
 function remove_todo(next_steps) {
@@ -88,14 +87,6 @@ function update_empty_container(next_steps) {
   <% else -%>
     $('div#no_todos_in_view').fadeOut(100, function(){ next_steps.go(); });
   <% end -%>
-}
-
-function update_badge_count() {
-  <%
-    count = source_view_is(:context) ? @remaining_in_context : @down_count
-    count = @project_changed ? @remaining_undone_in_project : count
-  -%>
-  TracksPages.set_page_badge(<%= count %>);
 }
 
 function insert_new_container_with_updated_todo(next_steps) {

--- a/app/views/users/destroy.js.erb
+++ b/app/views/users/destroy.js.erb
@@ -1,6 +1,5 @@
 <% if @saved -%>
   remove_user_from_page();
-  TracksPages.set_page_badge(<%= @total_users %>);
   TracksPages.page_notify('notice', '<%=  t('users.destroy_successful', :login => @deleted_user.login) %>', 8);
 <% else -%>
   TracksPages.page_notify('error', '<%=  t('users.destroy_error', :login => @deleted_user.login) %>', 8);

--- a/test/functional/calendar_controller_test.rb
+++ b/test/functional/calendar_controller_test.rb
@@ -25,7 +25,6 @@ class CalendarControllerTest < ActionController::TestCase
     assert_equal due_next_week, assigns['calendar'].due_next_week
     assert_equal due_this_month, assigns['calendar'].due_this_month
     assert_equal [], assigns['calendar'].due_after_this_month
-    assert_equal 8, assigns['count']
   end
 
   def test_show_ics

--- a/test/functional/todos_controller_test.rb
+++ b/test/functional/todos_controller_test.rb
@@ -327,14 +327,6 @@ class TodosControllerTest < ActionController::TestCase
     assert_nil t.project_id
   end
 
-  def test_update_todo_to_deferred_is_reflected_in_badge_count
-    login_as(:admin_user)
-    get :index
-    assert_equal 11, assigns['count']
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Make more money than Billy Gates", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006", "show_from"=>"30/11/2030"}, "tag_list"=>"foo bar"
-    assert_equal 10, assigns['down_count']
-  end
-
   def test_update_todo
     t = Todo.find(1)
     login_as(:admin_user)


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #185](https://www.assembla.com/spaces/tracks-tickets/tickets/185), now #1652._

The count in the badge is highly context dependent and in many cases, it's completely unclear in the UI as to what the count actually is. This is also reflected in the code with the use of a global `@count` instance variable.

This removes the feature by removing the global `@count` variable throughout the application and the other relevant pieces that refer to it. It's left in place in one controller where it was actually overridden to serve a different purpose.

:construction: Let's discuss. Also note that this is not finished yet. The cucumber scenarios fail, for example. :construction: 
