### PR TITLE
Use HTTPS URIs for git repos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'sass-rails', '~>4.0.0'
 gem 'coffee-rails', '~>4.0.0'
 
 # todo: remove xml api 
-gem 'actionpack-xml_parser', github: 'rails/actionpack-xml_parser'
+gem 'actionpack-xml_parser', git: 'https://github.com/rails/actionpack-xml_parser'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/rails/actionpack-xml_parser.git
+  remote: https://github.com/rails/actionpack-xml_parser
   revision: 246653ab3670f329176c1e77e6cd1a632466f06e
   specs:
     actionpack-xml_parser (1.0.0)


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #187](https://www.assembla.com/spaces/tracks-tickets/tickets/187), now #1654._

For people behind firewalls, the `git://` URIs that bundler uses by default won't work.

Manually specify the HTTPS URI for Git repos so that they work behind firewalls.

I think this should be a bit less controversial than my last pull request :smiley:
