### PR TITLE
Move calendar test down to unit tests

### DIFF
--- a/test/controllers/calendar_controller_test.rb
+++ b/test/controllers/calendar_controller_test.rb
@@ -1,10 +1,6 @@
 require_relative '../test_helper'
 
 class CalendarControllerTest < ActionController::TestCase
-  def setup
-    todos(:call_bill).update_attribute(:due, Time.zone.now.end_of_month.beginning_of_day)
-    todos(:call_dino_ext).update_attribute(:due, Time.zone.now.end_of_month.beginning_of_day)
-  end
     
   def test_show
     login_as(:admin_user)
@@ -14,22 +10,9 @@ class CalendarControllerTest < ActionController::TestCase
     projects = [projects(:timemachine),
                 projects(:moremoney),
                 projects(:gardenclean)]
-    due_today = [todos(:phone_grandfather),
-                 todos(:call_bill_gates_every_day),
-                 todos(:due_today)]
-    due_next_week = [todos(:buy_shares),
-                     todos(:buy_stego_bait),
-                     todos(:new_action_in_context)]
-    due_this_month = [todos(:call_bill),
-                      todos(:call_dino_ext)]
 
     assert_equal "calendar", assigns['source_view']
     assert_equal projects, assigns['projects']
-    assert_equal due_today, assigns['calendar'].due_today
-    assert_equal [], assigns['calendar'].due_this_week
-    assert_equal due_next_week, assigns['calendar'].due_next_week
-    assert_equal due_this_month, assigns['calendar'].due_this_month
-    assert_equal [], assigns['calendar'].due_after_this_month
     assert_equal 8, assigns['count']
   end
 

--- a/test/models/todos/calendar_test.rb
+++ b/test/models/todos/calendar_test.rb
@@ -1,0 +1,47 @@
+require_relative '../../test_helper'
+
+module Todos
+  class CalendarTest < ActiveSupport::TestCase
+
+    def setup
+      @calendar = Calendar.new(users(:admin_user))
+      Todo.destroy_all
+    end
+
+    def create_todo(due_date)
+      Todo.create due: due_date,
+        user: users(:admin_user),
+        description: 'Test Todo',
+        context: Context.first
+    end
+
+    def test_due_today
+      due_today = create_todo(Time.zone.now)
+
+      assert_equal [due_today], @calendar.due_today
+    end
+
+    def test_due_this_week
+      due_this_week = create_todo(Time.zone.now.end_of_week)
+      assert_equal [due_this_week], @calendar.due_this_week
+    end
+
+    def test_due_next_week
+      due_next_week = create_todo(1.week.from_now.beginning_of_day)
+
+      assert_equal [due_next_week], @calendar.due_next_week
+    end
+
+    def test_due_this_month
+      due_this_month = create_todo(Time.zone.now.end_of_month)
+
+      assert_equal [due_this_month], @calendar.due_this_month
+    end
+
+    def test_due_after_this_month
+      due_after_this_month = create_todo(1.month.from_now)
+      assert_equal [due_after_this_month], @calendar.due_after_this_month
+    end
+  end
+end
+


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #198](https://www.assembla.com/spaces/tracks-tickets/tickets/198), now #1665._

Remove tests that are specific to the calendar model from controller
test and move them to unit tests.
