### PR TITLE
Fixing bug #1442

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -377,7 +377,7 @@ class StatsController < ApplicationController
   # the block should return an array of indexes each is added to the hash and summed
   def convert_to_array(records, upper_bound)
     a = Array.new(upper_bound, 0)
-    records.each { |r| (yield r).each { |i| a[i] += 1 } }
+    records.each { |r| (yield r).each { |i| a[i] += 1 if a[i] } }
     a
   end
   

--- a/test/controllers/stats_controller_test.rb
+++ b/test/controllers/stats_controller_test.rb
@@ -142,6 +142,28 @@ class StatsControllerTest < ActionController::TestCase
     end
   end
 
+  def test_empty_last12months_data
+    Timecop.travel(Time.local(2013, 1, 15)) do
+      login_as(:admin_user)
+      @current_user = User.find(users(:admin_user).id)
+      @current_user.todos.delete_all
+      given_todos_for_stats
+      get :actions_done_last12months_data
+      assert_response :success
+    end
+  end
+
+  def test_out_of_bounds_events_for_last12months_data
+    login_as(:admin_user)
+    @current_user = User.find(users(:admin_user).id)
+    @current_user.todos.delete_all
+    create_todo_in_past(2.years)
+    create_todo_in_past(15.months)
+
+    get :actions_done_last12months_data
+    assert_response :success
+  end
+
   def test_actions_done_last30days_data
     login_as(:admin_user)
     @current_user = User.find(users(:admin_user).id)


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #201](https://www.assembla.com/spaces/tracks-tickets/tickets/201), now #1668._

This bug was caused when the chart encountered data outside of its
visible range (i.e., the upper bound of the array size). A test was
added that inserts some data from 2 years and 16 months in the past.
The test failed on the old version, throwing exactly the error in bug
report #1442.

The suggested fix is to check whether or not the array index is defined 
before sending the "+=" operator. With this change, the test passes.

I also added a test for a completely empty set of data.  That passed
before and after my changes.
