### PR TITLE
Update repo URL in installation instructions

### DIFF
--- a/doc/installation.textile
+++ b/doc/installation.textile
@@ -10,7 +10,7 @@ There are two methods of downloading Tracks:
 # If you want to live on the edge, you can get the latest development version from GitHub using git (bear in mind that this may be less stable than the released versions):
 
 bc. cd ~/Sites
-git clone git://github.com/tracksapp/tracks.git
+git clone git@github.com:TracksApp/tracks.git
 cd tracks
 
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #203](https://www.assembla.com/spaces/tracks-tickets/tickets/203), now #1670._

I got a "Repository not found" error when attempting to follow these installation instructions.

```
[10:12:28] ../opensource $ git clone git://github.com/tracksapp/tracks.git
Cloning into 'tracks'...
fatal: remote error:
  Repository not found.
[10:12:34] ../opensource $ git clone git@github.com:TracksApp/tracks.git
Cloning into 'tracks'...
remote: Counting objects: 40754, done.
remote: Compressing objects: 100% (12445/12445), done.
remote: Total 40754 (delta 27328), reused 39791 (delta 26547)
Receiving objects: 100% (40754/40754), 16.98 MiB | 1.90 MiB/s, done.
Resolving deltas: 100% (27328/27328), done.
```
