### PR TITLE
Add rake task to check for deprecated password hashes

### DIFF
--- a/lib/tasks/tracks.rake
+++ b/lib/tasks/tracks.rake
@@ -20,5 +20,15 @@ namespace :tracks do
       user.errors.each_full { |msg| puts "- #{msg}\n" }
     end
   end
+
+  desc 'Check all passwords for deprecated hashes'
+  task :check_passwords => :environment do
+    puts "The following users have deprecated password hashes:"
+    User.all.each do |user|
+      if user.uses_deprecated_password?
+        puts "  #{user.login}"
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #217](https://www.assembla.com/spaces/tracks-tickets/tickets/217), now #1684._

I'd like to get this into the next release so that we can use it in a _later_ release (probably 3.0) as a pre-upgrade step. This will allow us to purge the deprecated-password logic, including the entire use of `config.salt`, in the later release. That logic should not have remained in the code base for more than one version.
