### PR TITLE
Getting ready for Teatro.io cloud stage server

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,8 @@
+stage:
+  before:
+    - cp config/site.teatro.yml config/site.yml
+    - cp config/database.teatro.yml config/database.yml
+
+  database:
+    - bundle exec rake db:create db:migrate
+    - bundle exec rake db:seed

--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,5 @@ group :test do
   # get test coverage info on codeclimate
   gem "codeclimate-test-reporter", group: :test, require: nil
 end
+
+gem "thin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,10 +75,12 @@ GEM
       mime-types (~> 1.16)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
+    daemons (1.1.9)
     database_cleaner (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
     erubis (2.7.0)
+    eventmachine (1.0.3)
     execjs (2.0.2)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
@@ -176,6 +178,10 @@ GEM
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
+    thin (1.6.2)
+      daemons (>= 1.0.9)
+      eventmachine (>= 1.0.0)
+      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.3)
     tilt (1.4.1)
@@ -232,6 +238,7 @@ DEPENDENCIES
   sqlite3
   swf_fu
   therubyracer
+  thin
   tolk (>= 1.5.0)
   uglifier (>= 1.3.0)
   will_paginate

--- a/config/database.teatro.yml
+++ b/config/database.teatro.yml
@@ -1,0 +1,12 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8
+  reconnect: true
+  database: teatro
+  pool: 5
+
+development:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/site.teatro.yml
+++ b/config/site.teatro.yml
@@ -1,0 +1,77 @@
+# This is the 'salt' to add to the password before it is encrypted
+# You need to change this to something unique for yourself
+salt: "change-me"
+
+
+# NOTE: openid, ldap and cas are currently not supported anymore.
+authentication_schemes:
+  - "database"
+
+
+# You'll probably want to change this to the time zone of the computer where
+# Tracks is running. Run rake time:zones:local have Rails suggest time zone
+# names on your system
+time_zone: "UTC"
+
+
+# setting this to true will make the cookies only available over HTTPS
+secure_cookies: false
+
+
+# Your secret key for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+#
+# if you want a nice random key, run this in rails console and copy-and-paste
+# the result:
+#
+#   SecureRandom.hex(64)
+#
+secret_token: "change-me"
+
+
+# Uncomment if you want to dispatch todos that come from email based on the To:
+# address rather than the From: address.
+# email_dispatch: 'to'
+
+
+# If you want to send all email to a specific user, uncomment the following line
+# and set the environment variable TRACKS_MAIL_RECEIVER to the login name of the
+# user that will receive all email
+# email_dispatch: 'single_user'
+
+
+# Set this to the subdirectory you're hosting tracks in and uncomment if
+# applicable. NOTE: you will also need to set up your web server to deal with
+# the relative URL. Mongrel, for example, has a --prefix option.
+# subdir: "/tracks"
+
+
+# Set to true to allow anyone to sign up for a username.
+open_signups: true
+
+
+# When integrating your tracks instance with http://cloudmailin.com/ by using
+# the /integrations/cloudmailin URL, this value is the cloudmailin-secret for
+# verifying the authenticity of the request.
+# (see http://docs.cloudmailin.com/validating_the_sender)
+# cloudmailin: asdasd
+
+# Mailgun api key - used to verify incoming HTTP requests from Mailgun.org
+# mailgun_api_key: key-abcdef1234567890
+
+# change this to reflect the email address of the admin that you want to show
+# on the signup page
+admin_email: trackapp-admin@teatro.io
+
+
+# Map of allowed incoming email addresses to real users
+# Requires email_dispatch == 'to'
+# This allows you to specify _who_ can send email Todos to your list
+# The format is your incoming email (as per preferences page) for the key, and
+# an array-list of acceptable senders for that account
+#mailmap:
+#  'user@preferences.from.value':
+#  - 'acceptable1@personal.org'
+#  - 'acceptable2@work.com'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,75 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+puts "Seeding..."
+ActiveRecord::Base.transaction do
+  user = User.create!(
+    login: "teatro",
+    password: "teatro",
+    password_confirmation: "teatro",
+    is_admin: true,
+    first_name: "John",
+    last_name: "Doe",
+    auth_type: "database"
+  )
+
+  user.create_preference!
+
+  context = Context.create!(
+    name: "work",
+    user_id: user.id,
+    state: "active"
+  )
+
+  project = Project.create!(
+    name: "Teatro Development",
+    user_id: user.id,
+    state: "active"
+  )
+
+  Todo.create!([
+    {
+      context_id: context.id,
+      project_id: nil,
+      description: "Create a to-do list",
+      due: 5.days.from_now,
+      completed_at: 1.day.ago,
+      user_id: 1,
+      state: "completed"
+    }, {
+      context_id: context.id,
+      project_id: nil,
+      description: "Put a check mark",
+      user_id: 1,
+      state: "active"
+    }, {
+      context_id: context.id,
+      project_id: nil,
+      description: "Have a fun",
+      user_id: 1,
+      state: "active"
+    }, {
+      context_id: context.id,
+      project_id: project.id,
+      description: "Create a project",
+      user_id: 1,
+      state: "active"
+    }, {
+      context_id: context.id,
+      project_id: project.id,
+      description: "Have a dinner",
+      notes: "Visit a good restaurant",
+      user_id: 1,
+      state: "active"
+    }, {
+      context_id: context.id,
+      project_id: project.id,
+      description: "Write a code",
+      due: 3.days.from_now,
+      user_id: 1,
+      state: "active"
+    }
+  ])
+
+  puts "Seeding done"
+end


### PR DESCRIPTION
_This issue number may also refer to the [older ticket #222](https://www.assembla.com/spaces/tracks-tickets/tickets/222), now #1689._

Teatro.io is a cloud stage server (http://Teatro.io).
Currently we (team of Teatro) seek for open source projects and adapt them to run in that environment (for demo purposes).

Now we adapted TracksApp: http://master.b1df86e9d43fb943dddea44797df2e1e.ttrcloud.com/ (teatro:teatro)
But this is just a fork. We want TracksApp to support Teatro out-of-the-box from original repo.

Good side effect is you'll have live demo app on Teatro.io.

Please merge.
