### PR TITLE
Make activated todo in hidden project stay hidden

### DIFF
--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -76,9 +76,10 @@ class Todo < ActiveRecord::Base
   aasm.event :activate do
     transitions :to => :active, :from => [:project_hidden, :deferred]
     transitions :to => :active, :from => [:completed], :guard => :no_uncompleted_predecessors?
-    transitions :to => :active, :from => [:pending], :guard => :no_uncompleted_predecessors_or_deferral?
+    transitions :to => :active, :from => [:pending], :guard => :guard_for_transition_from_pending_to_active
     transitions :to => :pending, :from => [:completed], :guard => :uncompleted_predecessors?
     transitions :to => :deferred, :from => [:pending], :guard => :guard_for_transition_from_pending_to_deferred
+    transitions :to => :project_hidden, :from => [:pending], :guard => :guard_for_transition_from_pending_to_project_hidden
   end
 
   aasm.event :hide do
@@ -142,8 +143,16 @@ class Todo < ActiveRecord::Base
     return !uncompleted_predecessors.all.empty?
   end
 
+  def guard_for_transition_from_pending_to_active
+    no_uncompleted_predecessors_or_deferral? && not_part_of_hidden_container?
+  end
+
   def guard_for_transition_from_pending_to_deferred
     no_uncompleted_predecessors? && not_part_of_hidden_container?
+  end
+
+  def guard_for_transition_from_pending_to_project_hidden
+    no_uncompleted_predecessors? && part_of_hidden_container?
   end
 
   def part_of_hidden_container?

--- a/test/unit/todo_test.rb
+++ b/test/unit/todo_test.rb
@@ -244,6 +244,25 @@ class TodoTest < ActiveSupport::TestCase
     assert todo.reload.hidden?, "todo should be put back in hidden state"
   end
 
+  def test_dependent_todo_in_hidden_project_remains_hidden
+    todo = todos(:call_bill)
+    project=todo.project
+    project.hide!
+
+    assert todo.reload.hidden?, "todo in hidden project should be hidden"
+
+    todo2 = todos(:call_dino_ext)
+    todo.add_predecessor(todo2)
+    todo.block!
+
+    assert todo.pending?, "todo with predecessor should be blocked"
+
+    todo2.toggle_completion!
+    todo.activate!
+
+    assert todo.reload.hidden?, "todo should be put back in hidden state"
+  end
+
   def test_todo_specification_handles_null_project
     # @not_completed1 has a project
     todo_desc = @not_completed1.description


### PR DESCRIPTION
This is an area of the code I haven't touched before, so I'd like feedback before merging this.

I can't think of a really clean way to fix this issue (#1417) without revisions to the states, which I don't want to do for 2.2.3. And the logic for this currently spills into the controller, but I wanted to keep this in the model. So this is what I came up with. Is it an abuse of the state machine or is this an acceptable change?
