### PR TITLE
Add an object to represent the sidebar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -212,12 +212,7 @@ class ApplicationController < ActionController::Base
   end
 
   def init_data_for_sidebar
-    @completed_projects = current_user.projects.completed
-    @hidden_projects = current_user.projects.hidden
-    @active_projects = current_user.projects.active
-
-    @active_contexts = current_user.contexts.active
-    @hidden_contexts = current_user.contexts.hidden
+    @sidebar = Sidebar.new(current_user)
 
     init_not_done_counts
     if prefs.show_hidden_projects_in_sidebar

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -562,11 +562,7 @@ class TodosController < ApplicationController
       format.html do
         init_not_done_counts
         init_project_hidden_todo_counts
-        @active_projects = current_user.projects.active
-        @active_contexts = current_user.contexts.active
-        @hidden_projects = current_user.projects.hidden
-        @hidden_contexts = current_user.contexts.hidden
-        @completed_projects = current_user.projects.completed
+        init_data_for_sidebar unless mobile?
       end
       format.m
       format.xml { render :xml => @not_done_todos.to_xml( *todo_xml_params ) }

--- a/app/models/sidebar.rb
+++ b/app/models/sidebar.rb
@@ -1,0 +1,29 @@
+class Sidebar
+  attr_reader :contexts, :projects
+
+  def initialize(user)
+    user = user
+    @contexts = user.contexts
+    @projects = user.projects
+  end
+
+  def active_contexts
+    @active_contexts ||= contexts.active
+  end
+
+  def hidden_contexts
+    @hidden_contexts ||= contexts.hidden
+  end
+
+  def active_projects
+    @active_projects ||= projects.active
+  end
+
+  def hidden_projects
+    @hidden_projects ||= projects.hidden
+  end
+
+  def completed_projects
+    @completed_projects ||= projects.completed
+  end
+end

--- a/app/views/sidebar/sidebar.html.erb
+++ b/app/views/sidebar/sidebar.html.erb
@@ -1,7 +1,7 @@
 <div id="sidebar">
-  <%= sidebar_html_for_titled_list(@active_projects, t('sidebar.list_name_active_projects'))%>
-  <%= sidebar_html_for_titled_list(@active_contexts, t('sidebar.list_name_active_contexts'))%>
-  <%= sidebar_html_for_titled_list(@hidden_projects, t('sidebar.list_name_hidden_projects')) if prefs.show_hidden_projects_in_sidebar %>
-  <%= sidebar_html_for_titled_list(@completed_projects, t('sidebar.list_name_completed_projects')) if prefs.show_completed_projects_in_sidebar %>
-  <%= sidebar_html_for_titled_list(@hidden_contexts, t('sidebar.list_name_hidden_contexts')) if prefs.show_hidden_contexts_in_sidebar %>
+  <%= sidebar_html_for_titled_list(@sidebar.active_projects, t('sidebar.list_name_active_projects'))%>
+  <%= sidebar_html_for_titled_list(@sidebar.active_contexts, t('sidebar.list_name_active_contexts'))%>
+  <%= sidebar_html_for_titled_list(@sidebar.hidden_projects, t('sidebar.list_name_hidden_projects')) if prefs.show_hidden_projects_in_sidebar %>
+  <%= sidebar_html_for_titled_list(@sidebar.completed_projects, t('sidebar.list_name_completed_projects')) if prefs.show_completed_projects_in_sidebar %>
+  <%= sidebar_html_for_titled_list(@sidebar.hidden_contexts, t('sidebar.list_name_hidden_contexts')) if prefs.show_hidden_contexts_in_sidebar %>
 </div>

--- a/test/models/sidebar_test.rb
+++ b/test/models/sidebar_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class SidebarTest < ActiveSupport::TestCase
+
+  def setup
+    @sidebar = Sidebar.new(users(:admin_user))
+  end
+
+  def test_it_gets_the_active_contexts
+    assert @sidebar.active_contexts == users(:admin_user).contexts.active
+  end
+
+  def test_it_gets_the_hidden_contexts
+    assert @sidebar.hidden_contexts == users(:admin_user).contexts.hidden
+  end
+
+  def test_it_gets_the_active_projects
+    assert @sidebar.active_projects == users(:admin_user).projects.active
+  end
+
+  def test_it_gets_the_hidden_projects
+    assert @sidebar.hidden_projects == users(:admin_user).projects.hidden
+  end
+
+  def test_it_gets_the_completed_projects
+    assert @sidebar.completed_projects == users(:admin_user).projects.completed
+  end
+
+end


### PR DESCRIPTION
We're using a lot of the same instance variables throughout various controllers to populate the sidebar, so I thought it would be nice to pull them out into their own object.

After seeing this, I think there's some unification we can do between the mobile views and the normal views, but I'll save that for another pull request. :smiley:
