### PR TITLE
Move right submit button in mobile new action

### DIFF
--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -284,3 +284,8 @@ input#todo_description, input#tag_list, textarea#todo_notes, select#todo_project
 div.note_wrapper p {
     display: inline;
 }
+
+.text-right {
+    text-align: right;
+}
+

--- a/app/views/todos/new.m.erb
+++ b/app/views/todos/new.m.erb
@@ -1,5 +1,6 @@
 <%= form_tag todos_path(:format => 'm'), :method => :post do %>
   <%= render :partial => 'edit_form' %>
-  <p><input type="submit" value="<%= t('common.create') %>" tabindex="12" accesskey="#" /></p>
+  <p class="text-right"><input type="submit" value="<%= t('common.create') %>" tabindex="12" accesskey="#" /></p>
 <% end -%>
 <%= link_to t('common.back'), @return_path %>
+


### PR DESCRIPTION
So that the new form looks like this:

![development _-_2014-12-15_23 23 16](https://cloud.githubusercontent.com/assets/65402/5446030/5e50a760-84b1-11e4-8be0-f080d263b1dd.png)

I think it improves a bit the usability of the form making it more difficult to click back when trying to submit the form (happened to me :( ).

In the future I would like to spend some time making the mobile interface a bit more finger friendly, even just by making targets a bit bigger (http://msdn.microsoft.com/en-us/library/windows/apps/hh465415.aspx#touch_targets). What do you think, is something of any interest? I use a lot the mobile interface of Tracks.
