### PR TITLE
Fix ActionDispatch::Cookies::CookieOverflow after initial signup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "cache_digests"
 # To use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 
+gem 'activerecord-session_store', github: 'rails/activerecord-session_store'
+
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 # gem 'turbolinks'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/rails/activerecord-session_store.git
+  revision: 1cc0daf77d542045da4f6a43cba9ce04c27453dd
+  specs:
+    activerecord-session_store (0.1.1)
+      actionpack (>= 4.0.0, < 5)
+      activerecord (>= 4.0.0, < 5)
+      railties (>= 4.0.0, < 5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -211,6 +220,7 @@ DEPENDENCIES
   aasm
   actionpack-xml_parser (>= 1.0.1)
   activerecord-deprecated_finders
+  activerecord-session_store!
   acts_as_list
   aruba (>= 0.5.4)
   bcrypt (~> 3.1.7)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = true
+  config.serve_static_assets = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_assets = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_tracksapp_session'
+Rails.application.config.session_store :active_record_store


### PR DESCRIPTION
Default :cookie_store can only hold 4K of data.
Upon first signup, following exception is thrown:
```
I, [2015-01-29T16:52:06.900449 #31028]  INFO -- : Started POST "/users" for 127.0.0.1 at 2015-01-29 16:52:06 +0100
I, [2015-01-29T16:52:06.945349 #31028]  INFO -- : Processing by UsersController#create as HTML
I, [2015-01-29T16:52:06.945514 #31028]  INFO -- :   Parameters: {"utf8"=>"✓", "authenticity_token"=>"8ihcH+0z8AZjZiCpgB9crHSpai/uxgaFDIZixdfEgzc=", "user"=>{"login"=>"vk password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}}
I, [2015-01-29T16:52:07.180296 #31028]  INFO -- : Redirected to http://localhost:3000/signup
I, [2015-01-29T16:52:07.180505 #31028]  INFO -- : Completed 302 Found in 235ms (ActiveRecord: 1.1ms)
F, [2015-01-29T16:52:07.182494 #31028] FATAL -- :
    ActionDispatch::Cookies::CookieOverflow (ActionDispatch::Cookies::CookieOverflow):
      actionpack (4.1.8) lib/action_dispatch/middleware/cookies.rb:529:in `[]='
      actionpack (4.1.8) lib/action_dispatch/middleware/session/cookie_store.rb:110:in `set_cookie'
...
```
This patch fixes this issue by changing session storage to the ActiveRecord session_store (for at least Ruby 2.0.0p353 / rails 4.1.8).