### PR TITLE
Use the Rails helpers in more places

### DIFF
--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -201,7 +201,7 @@ module TodosHelper
       :_source_view => (@source_view.underscore.gsub(/\s+/,'_') rescue "")}
     url[:_tag_name] = @tag_name if @source_view == 'tag'
 
-    return link_to(t('todos.convert_to_project'), url, {:class => "icon_item_to_project", :id => "to_project_#{dom_id(todo)}"})
+    link_to(t('todos.convert_to_project'), url, {:class => "icon_item_to_project", :id => dom_id(todo, "to_project")})
   end
 
   def collapsed_notes_image(todo)

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -191,7 +191,7 @@ module TodosHelper
   def remote_delete_dependency(todo, predecessor)
     link_to(
       image_tag("blank.png", :title => t('todos.remove_dependency'), :align => "absmiddle", :class => "delete_item"),
-      url_for({:controller => 'todos', :action => 'remove_predecessor', :id => todo.id}),
+      remove_predecessor_todo_path(todo),
       {:class => "delete_dependency_button", :x_predecessors_id => predecessor.id}
     )
   end

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -166,7 +166,7 @@ module TodosHelper
       t('todos.delete'),
       {:controller => 'todos', :action => 'destroy', :id => todo.id},
       :class => "icon_delete_item",
-      :id => "delete_#{dom_id(todo)}",
+      :id => dom_id(todo, "delete"),
       :x_confirm_message => t('todos.confirm_delete', :description => todo.description),
       :title => t('todos.delete_action'));
   end

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -154,10 +154,10 @@ module TodosHelper
 
   def remote_edit_button(todo=@todo)
     link_to(
-      image_tag("blank.png", :alt => t('todos.edit'), :align => "absmiddle", :id => 'edit_icon_todo_'+todo.id.to_s, :class => 'edit_item'),
-      {:controller => 'todos', :action => 'edit', :id => todo.id},
+      image_tag("blank.png", :alt => t('todos.edit'), :align => "absmiddle", :id => dom_id(todo, "edit_icon"), :class => 'edit_item'),
+      edit_todo_path(todo),
       :class => "icon edit_item",
-      :id => "icon_edit_todo_#{todo.id}",
+      :id => dom_id(todo, "icon_edit"),
       :title => t('todos.edit_action_with_description', :description => todo.description))
   end
 

--- a/test/helpers/todo_helpers_test.rb
+++ b/test/helpers/todo_helpers_test.rb
@@ -12,4 +12,11 @@ class TodosHelpersTest < ActionView::TestCase
     html = remote_delete_menu_item(todos(:call_bill))
     assert_equal "<a class=\"icon_delete_item\" href=\"/todos/1\" id=\"delete_todo_1\" title=\"Delete action\" x_confirm_message=\"Are you sure that you want to delete the action &#39;Call Bill Gates to find out how much he makes per day&#39;?\">Delete</a>", html
   end
+
+  test "remote_delete_dependency" do
+    todo = todos(:call_bill_gates_every_day)
+    predecessor = todos(:call_bill)
+    html = remote_delete_dependency(todo, predecessor)
+    assert_equal "<a class=\"delete_dependency_button\" href=\"/todos/18/remove_predecessor\" x_predecessors_id=\"1\"><img align=\"absmiddle\" alt=\"Blank\" class=\"delete_item\" src=\"/images/blank.png\" title=\"Remove dependency (does not delete the action)\" /></a>", html
+  end
 end

--- a/test/helpers/todo_helpers_test.rb
+++ b/test/helpers/todo_helpers_test.rb
@@ -7,4 +7,9 @@ class TodosHelpersTest < ActionView::TestCase
     html = remote_edit_button(todos(:call_bill))
     assert_equal "<a class=\"icon edit_item\" href=\"/todos/1/edit\" id=\"icon_edit_todo_1\" title=\"Edit the action &#39;Call Bill Gates to find out how much he makes per day&#39;\"><img align=\"absmiddle\" alt=\"Edit\" class=\"edit_item\" id=\"edit_icon_todo_1\" src=\"/images/blank.png\" /></a>", html
   end
+
+  test "remote_delete_menu" do
+    html = remote_delete_menu_item(todos(:call_bill))
+    assert_equal "<a class=\"icon_delete_item\" href=\"/todos/1\" id=\"delete_todo_1\" title=\"Delete action\" x_confirm_message=\"Are you sure that you want to delete the action &#39;Call Bill Gates to find out how much he makes per day&#39;?\">Delete</a>", html
+  end
 end

--- a/test/helpers/todo_helpers_test.rb
+++ b/test/helpers/todo_helpers_test.rb
@@ -19,4 +19,9 @@ class TodosHelpersTest < ActionView::TestCase
     html = remote_delete_dependency(todo, predecessor)
     assert_equal "<a class=\"delete_dependency_button\" href=\"/todos/18/remove_predecessor\" x_predecessors_id=\"1\"><img align=\"absmiddle\" alt=\"Blank\" class=\"delete_item\" src=\"/images/blank.png\" title=\"Remove dependency (does not delete the action)\" /></a>", html
   end
+
+  test "remote_promote_to_project_menu_item" do
+    html = remote_promote_to_project_menu_item(todos(:call_bill))
+    assert_equal "<a class=\"icon_item_to_project\" href=\"/todos/1/convert_to_project?_source_view=\" id=\"to_project_todo_1\">Make project</a>", html
+  end
 end

--- a/test/helpers/todo_helpers_test.rb
+++ b/test/helpers/todo_helpers_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class TodosHelpersTest < ActionView::TestCase
+  include TodosHelper
+
+  test "remote_edit_button" do
+    html = remote_edit_button(todos(:call_bill))
+    assert_equal "<a class=\"icon edit_item\" href=\"/todos/1/edit\" id=\"icon_edit_todo_1\" title=\"Edit the action &#39;Call Bill Gates to find out how much he makes per day&#39;\"><img align=\"absmiddle\" alt=\"Edit\" class=\"edit_item\" id=\"edit_icon_todo_1\" src=\"/images/blank.png\" /></a>", html
+  end
+end


### PR DESCRIPTION
I was reading through TodosHelper and noticed a few places where we weren't using the helpers Rails provides for thinks like model ids and routes, so I fixed those up. I also added some very rudimentary characterization tests along the way.