### PR TITLE
Use Thin instead of WEBrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "aasm"
 gem "htmlentities"
 gem "swf_fu"
 gem "rails_autolink"
+gem 'thin'
 
 # To use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,12 @@ GEM
       mime-types (>= 1.16, < 3)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
+    daemons (1.1.9)
     database_cleaner (1.3.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
+    eventmachine (1.0.7)
     execjs (2.2.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -181,6 +183,10 @@ GEM
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -236,6 +242,7 @@ DEPENDENCIES
   sqlite3
   swf_fu
   therubyracer
+  thin
   tolk (~> 1.6.0)
   uglifier (>= 1.3.0)
   will_paginate

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Removed support for deprecated password-hashing algorithm. This
   eliminates config.salt. Note the addition of a pre-upgrade step to
   check for obsolete passwords.
+* Thin replaces WEBrick as the included web server
 * Tracks is tested on Ruby 1.9.3, 2.0.0, 2.1, and 2.2.
 
 ## Version 2.3

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -72,7 +72,7 @@ Tracks is built upon a number of Ruby libraries (known as ‘gems’). The Bundl
 2. Open the file `config/database.yml` and edit the `production:` section with the details of your database. If you are using MySQL the `adapter:` line should read `adapter: mysql2`, `host: localhost` (in the majority of cases), and your username and password should match those you assigned when you created the database. If you are using SQLite3, you should have only two lines under the production section: `adapter: sqlite3` and `database: db/tracks.db`.
 3. Open the file `config/site.yml`, and read through the settings to make sure that they suit your setup. In most cases, all you need to change are the `secret_token`, the administrator email address (`admin_email`), and the time zone setting. For the time zone setting you can use the command `bundle exec rake time:zones:local` to see all available timezones on your machine
 4. If you are using Windows, you may need to check the ‘shebang’ lines (`#!/usr/bin/env ruby`) of the `/public/dispatch.*` files and all the files in the `/script` directory. They are set to `#!/usr/bin/env ruby` by default. This should work for all Unix based setups (Linux or Mac OS X), but Windows users will probably have to change it to something like `#c:/ruby/bin/ruby` to point to the Ruby binary on your system.
-5. If you intend to deploy Tracks with the built in webserver called WEBrick, you’ll need to change `config.serve_static_assets` to `true` in `config/environments/production.rb` in order for the images, stylesheets, and javascript files to be served correctly.
+5. If you intend to deploy Tracks using its included web server, you’ll need to change `config.serve_static_assets` to `true` in `config/environments/production.rb` in order for the images, stylesheets, and javascript files to be served correctly.
 
 ## Populate your database with the Tracks schema
 
@@ -94,7 +94,7 @@ While still in the Terminal inside the Tracks root directory, issue the followin
 
     bundle exec rails server -e production
 
-If all goes well, you should see some text informing you that the WEBrick server is running: `=> Rails application starting in production on http://0.0.0.0:3000`. If you are already running other services on port 3000, you need to select a different port when running the server, using the `-p` option.
+If all goes well, you should see some text informing you that the server is running: `=> Rails application starting in production on http://0.0.0.0:3000`. If you are already running other services on port 3000, you need to select a different port when running the server, using the `-p` option.
 
 ## Visit Tracks in a browser
 

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -15,7 +15,7 @@ That said. To upgrade:
 7. Precompile your static assets (css, javascript, etc.) by running `bundle exec rake assets:precompile RAILS_ENV=production`.
 8. Run `bundle exec rails server -e production` inside your Tracks 2.4devel directory to start up Tracks. Or use `-e development` if you intend to try your changes and get more log info.
 
-Please note that if you intend to use Tracks with the built in webserver called WEBrick for production, you’ll need to change `config.serve_static_assets` to `true` in `config/environments/production.rb` in order for the images, stylesheets, and javascript files to be served correctly.
+Please note that if you intend to deploy Tracks using its included web server, you’ll need to change `config.serve_static_assets` to `true` in `config/environments/production.rb` in order for the images, stylesheets, and javascript files to be served correctly.
 
 ## Upgrading from older versions of Tracks
 


### PR DESCRIPTION
Thin performs much better than WEBrick, and it's a drop-in replacement, requiring no operational or development changes.