### PR TITLE
Update Gemfile and install doc to use db groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'coffee-rails', '~> 4.0.1'
 gem 'actionpack-xml_parser', '~> 1.0.1'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer'
+gem 'therubyracer', group: :therubyracer
 
 gem 'uglifier', '~> 2.5.3'
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,11 +16,12 @@ gem 'uglifier', '~> 2.5.3'
 
 gem 'jquery-rails', '~> 3.1.2'
 
-# you may comment out the database driver you will not be using.
+# you may comment out the database driver(s) you will not be using.
 # This will prevent a native build of the driver. Building native drivers is not
-# always possible on all hosters
-gem "sqlite3", "~> 1.3.9"
-gem "mysql2", "~> 0.3.16"
+# always possible on all platforms
+# Alternatively use --without <group> arguments to bundler to not install that group
+gem "sqlite3", "~> 1.3.9", group: :sqlite
+gem "mysql2", "~> 0.3.16", group: :mysql
 
 gem "RedCloth", "~> 4.2.9"
 gem "sanitize", "~> 3.0.2"

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -50,8 +50,20 @@ You need to create a database and database-user to use with Tracks. For this, yo
 
 Tracks is built upon a number of Ruby libraries (known as ‘gems’). The Bundler tool makes it easy to install all the gems that Tracks needs, and ensures that they are all the correct versions.
 
-1. Edit the file `Gemfile` in the Tracks root directory. You may comment out any database drivers you will not be using. You may also comment out `therubyracer` if you are installing Tracks on Windows or Mac OS X, or if you have another JavaScript runtime such as Node.js installed.
-2. Run the command `bundle install --without development test` in the directory that you unzipped your Tracks download to.
+1. If you are installing Tracks on Windows or Mac OS X, or if you have another JavaScript runtime such as Node.js installed, edit the file `Gemfile` in the Tracks root directory, and comment out `therubyracer`.
+2. In the directory that you unzipped your Tracks download to, install all the appropriate gems by running:
+  * If you are using SQLite:
+
+        ```
+        bundle install --without development test mysql
+        ```
+
+  * If you are using MySQL:
+
+        ```
+        bundle install --without development test sqlite
+        ```
+
 3. Wait for Bundler to finish installing the necessary gems that Tracks needs. This can take some time depending on the speed of your internet connection and the speed of the system you’re installing Tracks on.
 
 ## Configure variables

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -50,8 +50,7 @@ You need to create a database and database-user to use with Tracks. For this, yo
 
 Tracks is built upon a number of Ruby libraries (known as ‘gems’). The Bundler tool makes it easy to install all the gems that Tracks needs, and ensures that they are all the correct versions.
 
-1. If you are installing Tracks on Windows or Mac OS X, or if you have another JavaScript runtime such as Node.js installed, edit the file `Gemfile` in the Tracks root directory, and comment out `therubyracer`.
-2. In the directory that you unzipped your Tracks download to, install all the appropriate gems by running:
+1. In the directory that you unzipped your Tracks download to, install all the appropriate gems by running:
   * If you are using SQLite:
 
         ```
@@ -64,7 +63,8 @@ Tracks is built upon a number of Ruby libraries (known as ‘gems’). The Bundl
         bundle install --without development test sqlite
         ```
 
-3. Wait for Bundler to finish installing the necessary gems that Tracks needs. This can take some time depending on the speed of your internet connection and the speed of the system you’re installing Tracks on.
+  * If you are installing Tracks on Windows or Mac OS X, or if you have another JavaScript runtime such as Node.js installed, you may also append `therubyracer` as an additional "without" parameter.
+2. Wait for Bundler to finish installing the necessary gems that Tracks needs. This can take some time depending on the speed of your internet connection and the speed of the system you’re installing Tracks on.
 
 ## Configure variables
 


### PR DESCRIPTION
This is a backport from master of #1764, #1765, and #1767

One of the aims of was to make it easier for me to package Tracks, and I'm currently packaging the 2.3 branch. So, having verified that the groups approach is acceptable (by getting it into master), here is the 2.3 backport. I've checked that bundle install still works and the versions are correct:

```
Installing sqlite3 1.3.10
Installing mysql2 0.3.16
```