### PR TITLE
Remove cache_digests gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ gem "aasm"
 gem "htmlentities"
 gem "swf_fu"
 gem "rails_autolink"
-gem "cache_digests"
 
 # To use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,9 +44,6 @@ GEM
     bullet (4.14.0)
       activesupport (>= 3.0.0)
       uniform_notifier (>= 1.6.0)
-    cache_digests (0.3.1)
-      actionpack (>= 3.2)
-      thread_safe
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -215,7 +212,6 @@ DEPENDENCIES
   aruba (>= 0.5.4)
   bcrypt (~> 3.1.7)
   bullet
-  cache_digests
   capybara
   codeclimate-test-reporter
   coffee-rails (~> 4.0)


### PR DESCRIPTION
cache_digests was the precursor to the native "Russian doll caching" built into Rails 4