### PR TITLE
do not activate already completed todos, fix #1778

### DIFF
--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -317,7 +317,7 @@ class Todo < ActiveRecord::Base
 
   # activate todos that should be activated if the current todo is completed
   def activate_pending_todos
-    pending_todos = successors.select {|t| t.uncompleted_predecessors.empty?}
+    pending_todos = successors.select { |t| t.uncompleted_predecessors.empty? and !t.completed? }
     pending_todos.each {|t| t.activate! }
     return pending_todos
   end

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -1003,6 +1003,24 @@ class TodosControllerTest < ActionController::TestCase
     assert t4.predecessors.map(&:id).include?(t3.id)
   end
 
+
+  def test_do_not_activate_done_successors
+    login_as(:admin_user)
+    predecessor = Todo.find(1)
+    successor = Todo.find(2)
+    successor.add_predecessor(predecessor)
+
+    successor.complete!
+    xhr :post, :toggle_check, :id => predecessor.id, :_source_view => 'todo'
+
+    predecessor.reload
+    successor.reload
+    assert !predecessor.active?
+    assert !successor.active?
+    assert predecessor.completed?
+    assert successor.completed?
+  end
+
   private
 
   def create_todo(params={})

--- a/test/models/todo_test.rb
+++ b/test/models/todo_test.rb
@@ -267,7 +267,7 @@ class TodoTest < ActiveSupport::TestCase
     assert !@not_completed1.starred?
   end
 
-  def test_hidden_todo_remains_hidden_after_getting_unblokked
+  def test_hidden_todo_remains_hidden_after_getting_unblocked
     todo = todos(:call_bill)
     project=todo.project
     project.hide!


### PR DESCRIPTION
Only activate successors which are not completed