### PR TITLE
Fix #1789

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,7 @@ group :test do
 
   gem "aruba", ">=0.5.4", :require => false
 
-  # Note that > 2.14 has problems, see:
-  # https://code.google.com/p/selenium/issues/detail?id=3075
-  gem "selenium-webdriver"
+  gem "selenium-webdriver", '>=2.45'
 
   # uncomment to use the webkit option. This depends on Qt being installed
   # gem "capybara-webkit"

--- a/app/assets/javascripts/tracks.js.erb
+++ b/app/assets/javascripts/tracks.js.erb
@@ -655,7 +655,7 @@ var ContextListPage = {
         $.post(relative_to_root('contexts/'+context_id), {
             'context[name]': value,
             '_method': 'put'
-        }, highlight);
+        }, highlight, 'script');
         return value;
     },
     setup_behavior: function() {

--- a/app/assets/javascripts/tracks.js.erb
+++ b/app/assets/javascripts/tracks.js.erb
@@ -13,8 +13,9 @@ var TracksForm = {
         }
         toggleLink.parent().toggleClass('hide_form');
     },
-    set_project_name: function (name) {
+    set_project_name_and_default_project_name: function (name) {
         $('input#todo_project_name').val(name);
+        $('#default_project_name_id').val(name);
     },
     set_project_name_for_multi_add: function (name) {
         $('#multi_todo_project_name').val(name);
@@ -28,9 +29,6 @@ var TracksForm = {
     set_context_name_and_default_context_name: function (name) {
         TracksForm.set_context_name(name);
         $('input[name=default_context_name]').val(name);
-    },
-    set_default_project_name: function (name) {
-        $('#default_project_name_id').val(name);
     },
     set_tag_list_and_default_tag_list: function (name) {
         $('input#tag_list').val(name);

--- a/app/assets/javascripts/tracks.js.erb
+++ b/app/assets/javascripts/tracks.js.erb
@@ -29,10 +29,8 @@ var TracksForm = {
         TracksForm.set_context_name(name);
         $('input[name=default_context_name]').val(name);
     },
-    set_project_name_and_default_project_name: function (name) {
-        TracksForm.set_project_name('');
+    set_default_project_name: function (name) {
         $('#default_project_name_id').val(name);
-        $('#project_name').html(name);
     },
     set_tag_list_and_default_tag_list: function (name) {
         $('input#tag_list').val(name);

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -231,6 +231,7 @@ class ProjectsController < ApplicationController
       elsif boolean_param('update_default_tags')
         template = 'projects/update_default_tags'
       elsif boolean_param('update_project_name')
+        # clicking on a project name in the project view gives a form triggering this
         @projects = current_user.projects
         template = 'projects/update_project_name'
       else

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -76,7 +76,7 @@ class TodosController < ApplicationController
   def create
     @source_view = params['_source_view'] || 'todo'
     @default_context = current_user.contexts.where(:name => params['default_context_name']).first
-    @default_project = current_user.projects.where(:name => params['default_project_name']).first if params['default_project_name'].present?
+    @default_project = current_user.projects.where(:name => params['default_project_name']).first
 
     @tag_name = params['_tag_name']
 

--- a/app/views/contexts/update.js.erb
+++ b/app/views/contexts/update.js.erb
@@ -18,6 +18,7 @@ var <%=object_name%> = {
       <% else -%>
         <%=object_name%>.replace_context_form_with_updated_context();
       <% end -%>
+      TracksForm.set_context_name("<%= escape_javascript(@context.name)%>");
     },
     remove_and_re_add_context: function() {
       $('#<%=dom_id(@context, 'container')%>').slideUp(500, function() {

--- a/app/views/contexts/update.js.erb
+++ b/app/views/contexts/update.js.erb
@@ -18,7 +18,7 @@ var <%=object_name%> = {
       <% else -%>
         <%=object_name%>.replace_context_form_with_updated_context();
       <% end -%>
-      TracksForm.set_context_name("<%= escape_javascript(@context.name)%>");
+      TracksForm.set_context_name_and_default_context_name("<%= escape_javascript(@context.name)%>");
     },
     remove_and_re_add_context: function() {
       $('#<%=dom_id(@context, 'container')%>').slideUp(500, function() {

--- a/app/views/projects/update.js.erb
+++ b/app/views/projects/update.js.erb
@@ -33,7 +33,7 @@ var <%=object_name%> = {
     update_project_page: function() {
       <%=object_name%>.remove_project_edit_form();
       <%=object_name%>.update_and_show_project_settings();
-      TracksForm.set_project_name("<%= escape_javascript(@project.name)%>");
+      TracksForm.set_project_name_and_default_project_name("<%= escape_javascript(@project.name)%>");
       $("h2 span#project_name").html("<%= escape_javascript(@project.name)%>");
       <% if @project.default_context %>
         TracksForm.set_context_name_and_default_context_name("<%= escape_javascript(@project.default_context.name)%>");

--- a/app/views/projects/update.js.erb
+++ b/app/views/projects/update.js.erb
@@ -28,7 +28,6 @@ var <%=object_name%> = {
       <% end -%>
       ProjectListPage.update_all_states_count(<%=@active_projects_count%>, <%=@hidden_projects_count%>, <%=@completed_projects_count%>);
       ProjectListPage.show_or_hide_all_state_containers(<%= @show_active_projects %>, <%= @show_hidden_projects %>, <%= @show_completed_projects %>);
-      TracksForm.set_default_project_name("<%= escape_javascript(@project.name)%>");
       $('div.project-edit-current').removeClass('project-edit-current');
     },
     update_project_page: function() {

--- a/app/views/projects/update.js.erb
+++ b/app/views/projects/update.js.erb
@@ -28,7 +28,7 @@ var <%=object_name%> = {
       <% end -%>
       ProjectListPage.update_all_states_count(<%=@active_projects_count%>, <%=@hidden_projects_count%>, <%=@completed_projects_count%>);
       ProjectListPage.show_or_hide_all_state_containers(<%= @show_active_projects %>, <%= @show_hidden_projects %>, <%= @show_completed_projects %>);
-      TracksForm.set_project_name_and_default_project_name("<%= escape_javascript(@project.name)%>");
+      TracksForm.set_default_project_name("<%= escape_javascript(@project.name)%>");
       $('div.project-edit-current').removeClass('project-edit-current');
     },
     update_project_page: function() {

--- a/app/views/projects/update_project_name.js.erb
+++ b/app/views/projects/update_project_name.js.erb
@@ -1,4 +1,4 @@
 <% if @saved -%>
   TracksPages.page_inform('<%=t('projects.status_project_name_changed')%>');
-  TracksForm.set_project_name("<%= escape_javascript(@project.name)%>");
+  TracksForm.set_project_name_and_default_project_name("<%= escape_javascript(@project.name)%>");
 <% end %>

--- a/app/views/todos/create.js.erb
+++ b/app/views/todos/create.js.erb
@@ -28,7 +28,7 @@
     $('#todo-form-new-action').clearForm();
     $('#todo-form-new-action').clearDeps();
     TracksForm.set_context_name('<%=escape_javascript @initial_context_name%>');
-    TracksForm.set_project_name('<%=escape_javascript @initial_project_name%>');
+    TracksForm.set_project_name_and_default_project_name('<%=escape_javascript @initial_project_name%>');
     TracksForm.set_tag_list_and_default_tag_list('<%=escape_javascript @initial_tags%>');
     $('#todo-form-new-action input:text:first').focus();
     $('#new_todo_starred_link .todo_star').removeClass('starred');

--- a/features/add_todo_from_cli.feature
+++ b/features/add_todo_from_cli.feature
@@ -33,4 +33,4 @@ Feature: Add a todo to Tracks on console
 
       """
     When I execute the add-todo script
-    Then I should have 2 todo in project "Project A"
+    Then I should have 2 todos in project "Project A"

--- a/features/context_edit.feature
+++ b/features/context_edit.feature
@@ -21,6 +21,21 @@ Feature: Edit a context
     Then I should see that a context named "Errands" is not present
     And I should see that a context named "OutAndAbout" is present
 
+  # Ticket #1796
+  @javascript
+  Scenario: I can change the name of the project and it should update the new todo form
+    When I go to the context page for "@pc"
+    And I edit the context name in place to be "OutAndAbout"
+    Then the context field of the new todo form should contain "OutAndAbout"
+
+  # Ticket #1789
+  @javascript
+  Scenario: I can change the name of the context and it should still allow me to add new actions
+    When I go to the context page for "@pc"
+    And I edit the context name in place to be "OutAndAbout"
+    And I submit a new action with description "a new next action"
+    Then I should see the todo "a new next action"
+
   @javascript
   Scenario: Editing the context of a todo will remove the todo
     When I go to the the context page for "@pc"

--- a/features/project_edit.feature
+++ b/features/project_edit.feature
@@ -58,6 +58,16 @@ Feature: Edit a project
     Then the project title should be "cherries"
     And the project field of the new todo form should contain "cherries"
 
+  # Ticket #1789
+  @javascript
+  Scenario: I can change the name of the project and it should still allow me to add new actions
+    Given I have a project "bananas"
+    When I go to the "bananas" project
+    And I edit the project name to "cherries"
+    And I edit the default context to "@pc"
+    And I submit a new action with description "a new next action"
+    Then I should see the todo "a new next action"
+
   @javascript
   Scenario: I can change the default context of the project and it should update the new todo form
     Given I have a project "bananas" with 1 todos

--- a/features/step_definitions/project_steps.rb
+++ b/features/step_definitions/project_steps.rb
@@ -306,7 +306,7 @@ Then /^I should have a project called "([^"]*)"$/ do |project_name|
   expect(project).to_not be_nil
 end
 
-Then /^I should have (\d+) todo in project "([^"]*)"$/ do |todo_count, project_name|
+Then /^I should have (\d+) todo(?:s?) in project "([^"]*)"$/ do |todo_count, project_name|
   project = @current_user.projects.where(:name => project_name).first
   expect(project).to_not be_nil
   expect(project.todos.count).to eq(todo_count.to_i)

--- a/features/step_definitions/todo_steps.rb
+++ b/features/step_definitions/todo_steps.rb
@@ -119,6 +119,11 @@ Then /^the project field of the new todo form should contain "([^"]*)"$/ do |pro
   expect(page.find(:xpath, xpath).value).to eq(project_name)
 end
 
+Then /^the context field of the new todo form should contain "([^"]*)"$/ do |context_name|
+  xpath= "//form[@id='todo-form-new-action']/input[@id='todo_context_name']"
+  expect(page.find(:xpath, xpath).value).to eq(context_name)
+end
+
 Then /^the default context of the new todo form should be "([^"]*)"$/ do |context_name|
   xpath= "//form[@id='todo-form-new-action']/input[@id='todo_context_name']"
   expect(context_name).to eq(page.find(:xpath, xpath).value)

--- a/features/step_definitions/todo_steps.rb
+++ b/features/step_definitions/todo_steps.rb
@@ -116,7 +116,7 @@ end
 
 Then /^the project field of the new todo form should contain "([^"]*)"$/ do |project_name|
   xpath= "//form[@id='todo-form-new-action']/input[@id='todo_project_name']"
-  expect(project_name).to eq(page.find(:xpath, xpath).value)
+  expect(page.find(:xpath, xpath).value).to eq(project_name)
 end
 
 Then /^the default context of the new todo form should be "([^"]*)"$/ do |context_name|

--- a/features/support/tracks_step_helper.rb
+++ b/features/support/tracks_step_helper.rb
@@ -105,7 +105,7 @@ module TracksStepHelper
     execute_javascript "$('#{submenu_css}').parent().showSuperfishUl()"
 
     expect(page).to have_css(submenu_css, visible: true)
-    submenu = page.find(submenu_css, visible: true)
+    submenu = page.first(submenu_css, visible: true)
 
     within submenu do
       yield


### PR DESCRIPTION
The 'add new action' functionality needs to know the project id of the current project, which is computed using a (hidden) form value. This value needs to be updated whenever the program name is changed.

The old code updates the form in places where no form exists, which is now cleaned up.

Fixes #1789
Fixes #1796 