### PR TITLE
replace 'None' project by empty string

### DIFF
--- a/app/controllers/todos/todo_create_params_helper.rb
+++ b/app/controllers/todos/todo_create_params_helper.rb
@@ -104,7 +104,6 @@ module Todos
     def project_specified_by_name?
       return false if @attributes['project_id'].present?
       return false if project_name.blank?
-      return false if project_name == 'None'
       true
     end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1135,7 +1135,7 @@ end
   def update_project
     @project_changed = false;
     if params['todo']['project_id'].blank? && !params['project_name'].nil?
-      if params['project_name'] == 'None'
+      if params['project_name'].blank?
         project = Project.null_object
       else
         project = current_user.projects.where(:name => params['project_name'].strip).first

--- a/app/views/recurring_todos/_edit_form.html.erb
+++ b/app/views/recurring_todos/_edit_form.html.erb
@@ -11,7 +11,7 @@
       text_area_tag( "recurring_todo[notes]", @form_helper.notes, {:cols => 29, :rows => 6}) -%>
 
       <label for="edit_recurring_todo_project_name"><%= Todo.human_attribute_name('project') %></label>
-      <input id="edit_recurring_todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="<%= @form_helper.project.nil? ? 'None' : @form_helper.project.name.gsub(/"/,"&quot;") %>" />
+      <input id="edit_recurring_todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="<%= @form_helper.project.nil? ? '' : @form_helper.project.name.gsub(/"/,"&quot;") %>" />
       <div class="page_name_auto_complete" id="edit_project_list" style="display:none"></div>
 
       <label for="edit_recurring_todo_context_name"><%= Todo.human_attribute_name('context') %></label>

--- a/app/views/todos/_edit_form.html.erb
+++ b/app/views/todos/_edit_form.html.erb
@@ -22,7 +22,7 @@
 
   <div class="project_input">
     <label for="<%= dom_id(@todo, 'project_name') %>"><%= t('common.project') %></label>
-    <input id="<%= dom_id(@todo, 'project_name') %>" name="project_name" autocomplete="off" tabindex="<%= next_tab_index%>" size="30" type="text" value="<%= @todo.project.nil? ? 'None' : h(@todo.project.name) %>" />
+    <input id="<%= dom_id(@todo, 'project_name') %>" name="project_name" autocomplete="off" tabindex="<%= next_tab_index%>" size="30" type="text" value="<%= @todo.project.nil? ? '' : h(@todo.project.name) %>" />
   </div>
 
   <div class="context_input">

--- a/lib/tracks/attribute_handler.rb
+++ b/lib/tracks/attribute_handler.rb
@@ -89,7 +89,6 @@ module Tracks
     def project_specified_by_name?
       return false if get(:project_id).present?
       return false if project_name.blank?
-      return false if project_name == 'None'
       true
     end
 

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -319,10 +319,10 @@ class TodosControllerTest < ActionController::TestCase
     assert_equal 1, t.project_id
   end
 
-  def test_update_todo_project_to_none
+  def test_update_todo_delete_project
     t = Todo.find(1)
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"None", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar"
+    xhr :post, :update, :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar"
     t = Todo.find(1)
     assert_nil t.project_id
   end
@@ -384,7 +384,7 @@ class TodosControllerTest < ActionController::TestCase
     assert todo.project_hidden?, "todo should be project_hidden"
 
     # clear project from todo: the todo should be unhidden
-    xhr :post, :update, :id => todo.id, :_source_view => 'todo', "project_name"=>"None", "todo"=>{}
+    xhr :post, :update, :id => todo.id, :_source_view => 'todo', "project_name"=>"", "todo"=>{}
 
     assert assigns['project_changed'], "the project of the todo should be changed"
     todo = Todo.find(todo.id) # reload does not seem to work anymore

--- a/test/models/attribute_handler_test.rb
+++ b/test/models/attribute_handler_test.rb
@@ -55,8 +55,8 @@ class AttributeHandlerTest < ActiveSupport::TestCase
     h[:project_name] = "A project"
     assert h.project_specified_by_name?, "project is specified by name"
 
-    h[:project_name] = "None"
-    assert !h.project_specified_by_name?, "None is special token to specify nil-project"
+    h[:project_name] = ""
+    assert !h.project_specified_by_name?, "Blank string is special token to specify nil-project"
   end
 
   def test_context_specified_by_name

--- a/test/models/todo_create_params_helper_test.rb
+++ b/test/models/todo_create_params_helper_test.rb
@@ -102,8 +102,8 @@ class TodoCreateParamsHelperTest < ActiveSupport::TestCase
     assert_equal false, params_helper.project_specified_by_name?
   end
 
-  def test_project_specified_by_name_is_false_when_project_name_is_none
-    params = ActionController::Parameters.new({ 'project_name' => 'None', 'todo' => {} })
+  def test_project_specified_by_name_is_false_when_project_name_is_blank_string
+    params = ActionController::Parameters.new({ 'project_name' => '', 'todo' => {} })
     params_helper = Todos::TodoCreateParamsHelper.new(params, users(:admin_user))
     assert_equal false, params_helper.project_specified_by_name?
   end


### PR DESCRIPTION
I don't see why 'None' is better than the empty string, and this fixes #440. If you prefer still having 'None', please tell me what the advantages are.

Fix #440