### PR TITLE
Sort deferred actions by "show from" in tickler, #1727

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -558,7 +558,7 @@ class TodosController < ApplicationController
 
     includes = params[:format]=='xml' ? [:context, :project] : Todo::DEFAULT_INCLUDES
 
-    @not_done_todos = current_user.todos.deferred.includes(includes) + current_user.todos.pending.includes(includes)
+    @not_done_todos = current_user.todos.deferred.includes(includes).reorder('show_from') + current_user.todos.pending.includes(includes)
     @todos_without_project = @not_done_todos.select{|t|t.project.nil?}
     @down_count = @count = @not_done_todos.size
 

--- a/features/step_definitions/todo_create_steps.rb
+++ b/features/step_definitions/todo_create_steps.rb
@@ -100,9 +100,13 @@ Given /^I have ([0-9]+) deferred todos$/ do |count|
 end
 
 Given /^I have a deferred todo "([^"]*)" in the context "([^"]*)"$/ do |description, context_name|
+  step "I have a deferred todo \"#{description}\" in the context \"#{context_name}\" deferred by 7 days"
+end
+
+Given /^I have a (?:deferred )todo "([^"]*)" in the context "([^"]*)" deferred by (\d+) day(?:s)?$/ do |description, context_name, deferred_by_days|
   context = @current_user.contexts.where(:name => context_name).first_or_create
   todo = @current_user.todos.create!(:context_id => context.id, :description => description)
-  todo.show_from = UserTime.new(@current_user).time + 1.week
+  todo.show_from = UserTime.new(@current_user).time + deferred_by_days.to_i.day
   todo.save!
 end
 

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -110,6 +110,12 @@ Then /^(?:|I )should see "([^"]*)"(?: within "([^"]*)")?$/ do |text, selector|
   end
 end
 
+Then /^(?:|I )should see "([^"]*)" before "([^"]*)"$/ do |earlier_content, later_content|
+  expect(page).to have_content(earlier_content)
+  expect(page).to have_content(later_content)
+  page.body.index(earlier_content).should < page.body.index(later_content)
+end
+
 Then /^(?:|I )should see \/([^\/]*)\/(?: within "([^"]*)")?$/ do |regexp, selector|
   regexp = Regexp.new(regexp)
   with_scope(selector) do

--- a/features/tickler.feature
+++ b/features/tickler.feature
@@ -98,3 +98,12 @@ Feature: Manage deferred todos
       | grouping |
       | context  |
       | project  |
+
+  Scenario: Opening the tickler page shows the deferred todos in order
+    Given I have a deferred todo "show tomorrow" in the context "Context B" deferred by 1 day
+    And I have a deferred todo "show in a year" in the context "Context B" deferred by 365 days
+    And I have a deferred todo "show in a week" in the context "Context B" deferred by 7 days
+    When I go to the tickler page
+    Then I should see "show tomorrow" before "show in a week"
+    And I should see "show tomorrow" before "show in a year"
+    And I should see "show in a week" before "show in a year"


### PR DESCRIPTION
Fix #1727 by sorting the actions by "show_from" in the tickler.