### PR TITLE
Projects with completed actions may be blocked

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -109,7 +109,7 @@ class Project < ActiveRecord::Base
     ## mutually exclusive for stalled and blocked
     # blocked is uncompleted project with deferred or pending todos, but no next actions
     return false if self.completed?
-    return !self.todos.deferred_or_blocked.empty? && self.todos.not_deferred_or_blocked.empty?
+    return !self.todos.deferred_or_blocked.empty? && self.todos.active.empty?
   end
 
   def stalled?

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -198,7 +198,6 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_project_blocked
     p = users(:admin_user).projects.first
-    todo_in_other_project = users(:admin_user).projects.last.todos.first
 
     assert !p.blocked?, "first project should not be blocked"
 
@@ -208,6 +207,9 @@ class ProjectTest < ActiveSupport::TestCase
     p.activate!
     p.todos.each{|t| t.show_from = 2.weeks.from_now; t.save! }
     assert p.blocked?, "projects with deferred todos should be blocked"
+
+    p.todos.first.complete!
+    assert p.blocked?, "projects with deferred todo should be blocked even if a completed todo exists"
   end
 
   def test_project_stalled


### PR DESCRIPTION
Currently, a project cannot be blocked if at least one completed action exists. This was introduced in
acab98d4c7f2237bcd9fc44cd5e93a39582fe588, and I assume this change was not intended.