### PR TITLE
retain tags from action when transforming into project

### DIFF
--- a/lib/project_from_todo.rb
+++ b/lib/project_from_todo.rb
@@ -21,6 +21,7 @@ class ProjectFromTodo
       p.name = todo.description
       p.description = todo.notes
       p.default_context = todo.context
+      p.default_tags = todo.tag_list
       p.user = todo.user
     end
   end

--- a/test/models/project_from_todo_test.rb
+++ b/test/models/project_from_todo_test.rb
@@ -12,6 +12,13 @@ class ProjectFromTodoTest < ActiveSupport::TestCase
     assert_equal project.default_context, todo.context
   end
 
+  def test_retain_tags_from_todo
+    todo = todos(:upgrade_rails)
+    todo.tag_with "a, b"
+    project = ProjectFromTodo.new(todo).create
+    assert_equal "a, b", project.default_tags
+  end
+
   def test_invalid_project_from_invalid_todo
     todo = todos(:upgrade_rails)
     todo.description = ""


### PR DESCRIPTION
When creating a project out of an action, add the tags from the action as default tags for the project.

This fixes #1448.