### PR TITLE
Update cucumber version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :test do
 
   gem "aruba", ">=0.5.4", :require => false
 
-  gem "selenium-webdriver"
+  gem "selenium-webdriver", '>=2.45'
 
   # uncomment to use the webkit option. This depends on Qt being installed
   # gem "capybara-webkit"

--- a/Gemfile
+++ b/Gemfile
@@ -65,8 +65,6 @@ group :test do
 
   gem "aruba", ">=0.5.4", :require => false
 
-  # Note that > 2.14 has problems, see:
-  # https://code.google.com/p/selenium/issues/detail?id=3075
   gem "selenium-webdriver"
 
   # uncomment to use the webkit option. This depends on Qt being installed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 2.12)
       sprockets-rails (~> 2.0)
-    selenium-webdriver (2.43.0)
+    selenium-webdriver (2.45.0)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
@@ -235,7 +235,7 @@ DEPENDENCIES
   rspec-expectations
   sanitize
   sass-rails (~> 4.0)
-  selenium-webdriver
+  selenium-webdriver (>= 2.45)
   simplecov
   spring
   spring-commands-cucumber


### PR DESCRIPTION
Use newer version to fix problems with Firefox 35+.
`selenium-webdriver` older than 2.45 does not work with Firefox 35 and newer.