### PR TITLE
Fix cucumber test: select first menu

### DIFF
--- a/features/support/tracks_step_helper.rb
+++ b/features/support/tracks_step_helper.rb
@@ -105,7 +105,7 @@ module TracksStepHelper
     execute_javascript "$('#{submenu_css}').parent().showSuperfishUl()"
 
     expect(page).to have_css(submenu_css, visible: true)
-    submenu = page.find(submenu_css, visible: true)
+    submenu = page.first(submenu_css, visible: true)
 
     within submenu do
       yield


### PR DESCRIPTION
in 'Scenario: Deleting a todo will remove it from the calendar' there may be two menus if the test is run on the last day of the month.

Observed in this build: https://travis-ci.org/TracksApp/tracks/builds/56555704