### PR TITLE
Convert a .should expectation to expect()

### DIFF
--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -113,7 +113,7 @@ end
 Then /^(?:|I )should see "([^"]*)" before "([^"]*)"$/ do |earlier_content, later_content|
   expect(page).to have_content(earlier_content)
   expect(page).to have_content(later_content)
-  page.body.index(earlier_content).should < page.body.index(later_content)
+  expect(page.body.index(earlier_content)).to be < page.body.index(later_content)
 end
 
 Then /^(?:|I )should see \/([^\/]*)\/(?: within "([^"]*)")?$/ do |regexp, selector|


### PR DESCRIPTION
We're using RSpec 3 expectations syntax, in which `.should` is deprecated. This was throwing a deprecation warning.

FYI @C-Otto -- this was introduced in #1805.