### PR TITLE
Sort containers

### DIFF
--- a/app/assets/javascripts/tracks_pages.js
+++ b/app/assets/javascripts/tracks_pages.js
@@ -193,5 +193,21 @@ var TracksPages = {
 
     /* fade flashes and alerts in automatically */
     $(".alert").fadeOut(8000);
+  }, sort_container: function(container) {
+    function comparator(a, b) {
+        var contentA = $(a).attr('data-sort') || '';
+        var contentB = $(b).attr('data-sort') || '';
+        if (contentA > contentB) {
+            return 1;
+        }
+        if (contentB > contentA) {
+            return -1;
+        }
+        return 0;
+    }
+
+    var unsortedActions = container.children();
+    var sortedChildren = unsortedActions.sort(comparator);
+    container.append(sortedChildren);
   }
 };

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -357,6 +357,18 @@ module TodosHelper
     text_field_tag name, value, {"size" => 12, "id" => id, "class" => "Date", "autocomplete" => "off"}.update(options.stringify_keys)
   end
 
+  def sort_key(todo)
+    # actions are sorted using {order("todos.due IS NULL, todos.due ASC, todos.created_at ASC")}
+    # the JavaScript frontend sorts using unicode/ascii
+    format = "%Y%m%d%H%M%S%L"
+    if todo.due?
+      sort_by_due = todo.due.strftime format
+    else
+      sort_by_due = "Z" * 17 # length of format string
+    end
+    sort_by_due + todo.created_at.strftime(format)
+  end
+
   # === helpers for default layout
 
   def default_contexts_for_autocomplete

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -12,7 +12,7 @@ parameters += "&_tag_name=#{@tag_name}" if @source_view == 'tag'
 # also make different caches per source_view to handle difference in showing [C] and [P]
 cache [todo, current_user.date.strftime("%Y%m%d"), @source_view, current_user.prefs.verbose_action_descriptors] do
 %>
-  <div id="<%= dom_id(todo) %>" class="item-container">
+  <div id="<%= dom_id(todo) %>" class="item-container" data-sort="<%= sort_key(todo) %>">
     <div id="<%= dom_id(todo, 'line') %>" class="item-show">
       <%= remote_star_icon(todo) %>
       <%= remote_toggle_checkbox(todo) %>

--- a/app/views/todos/_update_successful.js.erb
+++ b/app/views/todos/_update_successful.js.erb
@@ -55,7 +55,7 @@ add_to_existing_container: function(next_steps) {
   <% end -%>
 },
 replace_todo: function(next_steps) {
-  $('#<%= dom_id(@todo) %>').html(<%=object_name%>.html_for_todo());
+  $('#<%= dom_id(@todo) %>').replaceWith(<%=object_name%>.html_for_todo());
   next_steps.go();
 },
 hide_container: function(next_steps) {

--- a/app/views/todos/_update_successful.js.erb
+++ b/app/views/todos/_update_successful.js.erb
@@ -56,6 +56,7 @@ add_to_existing_container: function(next_steps) {
 },
 replace_todo: function(next_steps) {
   $('#<%= dom_id(@todo) %>').replaceWith(<%=object_name%>.html_for_todo());
+  TracksPages.sort_container($('#<%= item_container_id(@todo) %>_items'));
   next_steps.go();
 },
 hide_container: function(next_steps) {

--- a/app/views/todos/_update_successful.js.erb
+++ b/app/views/todos/_update_successful.js.erb
@@ -29,7 +29,9 @@ remove_todo: function(next_steps) {
   });
 },
 add_to_existing_container: function(next_steps) {
-  $('#<%= item_container_id(@todo) %>_items').append(<%=object_name%>.html_for_todo());
+  var container = $('#<%= item_container_id(@todo) %>_items');
+  container.append(<%=object_name%>.html_for_todo());
+  TracksPages.sort_container(container);
   <% if source_view_is_one_of(:calendar) -%>
     next_steps.go();
     <% if (@target_context_count==1) || ( (@todo.deferred? || @todo.pending?) && @remaining_deferred_or_pending_count == 1) -%>

--- a/app/views/todos/create.js.erb
+++ b/app/views/todos/create.js.erb
@@ -49,7 +49,10 @@
 
   function add_todo_to_existing_container(next_steps) {
     $('#<%= empty_container_msg_div_id %>').hide();
-    $('#<%= item_container_id(@todo) %>_items').append(html_for_new_todo());
+    var container = $('#<%= item_container_id(@todo) %>_items');
+    container.append(html_for_new_todo());
+    TracksPages.sort_container(container);
+
     $('#<%= item_container_id(@todo) %>').slideDown(500, function() {
       $('#<%= dom_id(@todo) %>').effect('highlight', {}, 2000 );
       next_steps.go();

--- a/app/views/todos/destroy.js.erb
+++ b/app/views/todos/destroy.js.erb
@@ -54,7 +54,9 @@ function show_new_todo_if_todo_was_recurring() {
   <% if @todo.from_recurring_todo? -%>
     <%  unless @new_recurring_todo.nil? || @new_recurring_todo.deferred? -%>
       TodoItemsContainer.ensureVisibleWithEffectAppear("<%=item_container_id(@new_recurring_todo)%>");
-      $('#<%=item_container_id(@new_recurring_todo)%>_items').append(html_for_new_recurring_todo());
+      var container = $('#<%=item_container_id(@new_recurring_todo)%>_items');
+      container.append(html_for_new_recurring_todo());
+      TracksPages.sort_container(container);
       $('#<%= dom_id(@new_recurring_todo, 'line')%>').effect('highlight', {}, 2000 );
       TracksPages.page_inform("<%=t('todos.recurring_action_deleted')%>");
     <% else -%>

--- a/app/views/todos/destroy.js.erb
+++ b/app/views/todos/destroy.js.erb
@@ -75,11 +75,15 @@ function activate_pending_todos() {
         if source_view_is_one_of(:project,:tag) -%>
           $('#<%= dom_id(t) %>').fadeOut(400, function() {
             $('#<%= dom_id(t) %>').remove();
-            $('#<%= item_container_id(t) %>_items').append("<%= html %>");
+            var container = $('#<%= item_container_id(t) %>_items');
+            container.append("<%= html %>");
+            TracksPages.sort_container(container);
             <%= "$('#deferred_pending_container-empty-d').show();".html_safe if @remaining_deferred_or_pending_count==0 -%>
           });
  <%     else -%>
-          $('#<%= item_container_id(t) %>_items').append("<%= html%>");
+          var container = $('#<%= item_container_id(t) %>_items');
+          container.append("<%= html%>");
+          TracksPages.sort_container(container);
  <%     end -%>
         TodoItems.highlight_todo('#<%= dom_id(t, 'line')%>');
  <%   end -%>

--- a/app/views/todos/remove_predecessor.js.erb
+++ b/app/views/todos/remove_predecessor.js.erb
@@ -33,7 +33,7 @@ function update_successor() {
       $('#c<%= @successor.context_id %>').fadeIn(500, function() {});
       $('#no_todos_in_view').slideUp(100);
     <% end -%>
-    $('#<%=item_container_id(@successor)%>').append(html_for_new_successor());
+    $('#<%=item_container_id(@successor)%>_items').append(html_for_new_successor());
     $('#<%= dom_id(@successor, 'line')%>').effect('highlight', {}, 2000 ); <%
   elsif @successor.deferred? -%>
     $('#<%= dom_id(@successor)%>').html(html_for_new_successor()); <%

--- a/app/views/todos/remove_predecessor.js.erb
+++ b/app/views/todos/remove_predecessor.js.erb
@@ -10,7 +10,7 @@
 <% end -%>
 
 function replace_updated_predecessor() {
-  $('#<%= dom_id(@predecessor) %>').html( html_for_predecessor() );
+  $('#<%= dom_id(@predecessor) %>').replaceWith( html_for_predecessor() );
 }
 
 function regenerate_predecessor_family() {

--- a/app/views/todos/remove_predecessor.js.erb
+++ b/app/views/todos/remove_predecessor.js.erb
@@ -33,7 +33,9 @@ function update_successor() {
       $('#c<%= @successor.context_id %>').fadeIn(500, function() {});
       $('#no_todos_in_view').slideUp(100);
     <% end -%>
-    $('#<%=item_container_id(@successor)%>_items').append(html_for_new_successor());
+    var container = $('#<%=item_container_id(@successor)%>_items');
+    container.append(html_for_new_successor());
+    TracksPages.sort_container(container);
     $('#<%= dom_id(@successor, 'line')%>').effect('highlight', {}, 2000 ); <%
   elsif @successor.deferred? -%>
     $('#<%= dom_id(@successor)%>').html(html_for_new_successor()); <%

--- a/app/views/todos/toggle_check.js.erb
+++ b/app/views/todos/toggle_check.js.erb
@@ -64,7 +64,9 @@ var <%= object_name %> = {
     next_steps.go();
   },
   add_todo_to_container: function(next_steps) {
-    $('#<%= item_container_id(@todo) %>_items').append(<%=object_name%>.html_for_todo());
+    var container = $('#<%= item_container_id(@todo) %>_items');
+    container.append(<%=object_name%>.html_for_todo());
+    TracksPages.sort_container(container);
     <% if should_make_context_visible -%>
       $('#<%= item_container_id(@todo) %>').slideDown(500, function() {
         $("#<%= empty_container_msg_div_id %>").slideUp(100);

--- a/app/views/todos/toggle_check.js.erb
+++ b/app/views/todos/toggle_check.js.erb
@@ -127,11 +127,15 @@ var <%= object_name %> = {
           if source_view_is_one_of(:project,:tag) -%>
             $('#<%= dom_id(t) %>').slideUp(400, function() {
               $('#<%= dom_id(t) %>').remove();
-              $('#<%= item_container_id(t) %>_items').append("<%= html  %>");
+              var container = $('#<%= item_container_id(t) %>_items');
+              container.append("<%= html  %>");
+              TracksPages.sort_container(container);
               <%= "$('#deferred_pending_container-empty-d').show();".html_safe if @remaining_deferred_or_pending_count==0 -%>
             });
    <%     else -%>
-            $('#<%= item_container_id(t) %>_items').append("<%= html%>");
+            var container = $('#<%= item_container_id(t) %>_items');
+            container.append("<%= html%>");
+            TracksPages.sort_container(container);
    <%     end -%>
           TodoItems.highlight_todo('#<%= dom_id(t)%>');
    <%   end -%>

--- a/app/views/todos/toggle_check.js.erb
+++ b/app/views/todos/toggle_check.js.erb
@@ -84,7 +84,9 @@ var <%= object_name %> = {
     <%  # show new todo if the completed todo was recurring
       if @todo.from_recurring_todo?
         unless @new_recurring_todo.nil? || (@new_recurring_todo.deferred? && !source_view_is(:deferred)) -%>
-        $('#<%= item_container_id(@new_recurring_todo) %>_items').append(<%=object_name%>.html_for_recurring_todo());
+        var container = $('#<%= item_container_id(@new_recurring_todo) %>_items');
+        conainer.append(<%=object_name%>.html_for_recurring_todo());
+        TracksPages.sort_container(container);
         $('#c<%= @new_recurring_todo.context_id %>').slideDown(500, function() {
           <%=object_name%>.highlight_updated_recurring_todo(next_steps);
         });


### PR DESCRIPTION
Sort containers in JavaScript, for example when updating an action or creating a new one. This fixes #256.

This only works after re-rendering the todo partials. Any idea how to enforce this once?

I found some more places where we need to sort, this should cover about everything (feel free to tell me if I missed anything).

The JavaScript code has a few problems, and I might be looking into that soon. It seems we often try to change the contents of some action's div using .html(), which effectively adds a div inside the new div (both sharing the same id). Using replaceWith() might be the way to go, instead.