### PR TITLE
Fix description of monthly recurring tests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,13 +107,15 @@ module ApplicationHelper
   end
 
   def recurrence_pattern_as_text(recurring_todo)
-    rt = recurring_todo.recurring_target_as_text
-    rp = recurring_todo.recurrence_pattern
-    rp = " " + rp unless rp.nil?
-    rts = recurrence_time_span(recurring_todo)
-    # only add space if recurrence_time_span has content
-    rts = " " + rts unless rts == ""
-    return rt+rp+rts
+    recurring_target = recurring_todo.recurring_target_as_text
+
+    recurrence_pattern = recurring_todo.recurrence_pattern
+    recurrence_pattern = ' ' + recurrence_pattern unless recurrence_pattern.nil?
+
+    recurrence_time_span = recurrence_time_span(recurring_todo)
+    recurrence_time_span = ' ' + recurrence_time_span unless recurrence_time_span.empty?
+
+    recurring_target + recurrence_pattern + recurrence_time_span
   end
 
   def date_format_for_date_picker()

--- a/app/models/recurring_todos/monthly_recurrence_pattern.rb
+++ b/app/models/recurring_todos/monthly_recurrence_pattern.rb
@@ -118,8 +118,8 @@ module RecurringTodos
 
     def recurrence_pattern_for_specific_day
       on_day = " #{I18n.t('todos.recurrence.pattern.on_day_n', :n => every_x_day)}"
-      if every_xth_day(0) > 1
-        I18n.t("todos.recurrence.pattern.every_n_months", :n => every_xth_day) + on_day
+      if every_x_month > 1
+        I18n.t("todos.recurrence.pattern.every_n_months", :n => every_x_month) + on_day
       else
         I18n.t("todos.recurrence.pattern.every_month") + on_day
       end

--- a/test/models/recurring_todos/monthly_recurrence_pattern_test.rb
+++ b/test/models/recurring_todos/monthly_recurrence_pattern_test.rb
@@ -104,10 +104,10 @@ module RecurringTodos
       assert_equal "every last friday of every month", rt.recurrence_pattern
 
       rt.recurrence_selector = 0
-      assert_equal "every 5 months on day 1", rt.recurrence_pattern
-
-      rt.every_other3 = 1
       assert_equal "every month on day 1", rt.recurrence_pattern
+
+      rt.every_other2 = 4
+      assert_equal "every 4 months on day 1", rt.recurrence_pattern
     end
 
     def test_monthly_pattern


### PR DESCRIPTION
The test for monthly recurring actions confused the fields every_other2 and every_other3 in the database. This fixes #1847.