### PR TITLE
Do not open 'new note' form when clicking unrelated links

### DIFF
--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -19,7 +19,7 @@ img {
 #navcontainer, #input_box, #footer, .big-box, .refresh, .badge, h1, .icon,
 #minilinks, .defer-container, .menu_sort, .position, .buttons, .sf-item-menu,
 .container_toggle, .grip, .show_notes, .recurring_icon, #project-next-prev,
-.project_settings, .add_note_link {
+.project_settings, .link_in_container_header {
     display:none;
 }
 

--- a/app/assets/stylesheets/tracks.css.scss
+++ b/app/assets/stylesheets/tracks.css.scss
@@ -597,7 +597,7 @@ div.note_footer a, div.note_footer a:hover {
     padding: 5px;
 }
 
-div.add_note_link {
+div.link_in_container_header {
     margin-top:12px;
     float: right;
 }

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -113,7 +113,7 @@ module TodosHelper
     settings.reverse_merge!({
         :title => t("todos.actions.#{settings[:parent_container_type]}_#{settings[:container_name]}", :param => settings[:title_param])
       })
-    header = settings[:link_in_header].nil? ? "" : content_tag(:div, :class=>"add_note_link"){settings[:link_in_header]}
+    header = settings[:link_in_header].nil? ? "" : content_tag(:div, :class=>"link_in_container_header"){settings[:link_in_header]}
     header += content_tag(:h2) do
       toggle = settings[:collapsible] ? container_toggle("toggle_#{settings[:id]}") : ""
       "#{toggle} #{settings[:title]} #{settings[:append_descriptor]}".html_safe

--- a/app/views/projects/done.html.erb
+++ b/app/views/projects/done.html.erb
@@ -1,6 +1,6 @@
 <%
   paginate_options = {
-    :class => :add_note_link,
+    :class => :link_in_container_header,
     :previous_label => '&laquo; '+ t('common.previous'),
     :next_label     => t('common.next')+' &raquo;',
     :inner_window   => 2

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -25,7 +25,7 @@
 
   <div class="container">
     <div id="notes">
-      <div class="add_note_link"><%= link_to t('projects.add_note'), '#' %> </div>
+      <div class="add_note_link link_in_container_header"><%= link_to t('projects.add_note'), '#' %> </div>
       <h2><%= t('projects.notes') %></h2>
       <div id="empty-n" style="display:<%= @project.notes.empty? ? 'block' : 'none'%>;">
         <div class="message"><p><%= t('projects.no_notes_attached') %></p></div>

--- a/app/views/recurring_todos/done.html.erb
+++ b/app/views/recurring_todos/done.html.erb
@@ -1,6 +1,6 @@
 <%
   paginate_options = {
-    :class => :add_note_link,
+    :class => :link_in_container_header,
     :previous_label => '&laquo; '+ t('common.previous'),
     :next_label     => t('common.next')+' &raquo;',
     :inner_window   => 2

--- a/app/views/recurring_todos/index.html.erb
+++ b/app/views/recurring_todos/index.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class="container" id="completed_recurring_todos_container">
-    <div class=add_note_link><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
+    <div class="add_note_link"><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
     <h2><%= t('common.last') %> <%= t('todos.completed_recurring') %></h2>
     <div id="completed_recurring_todos_container">
       <div id="completed-empty-nd" style="<%= @no_completed_recurring_todos ? 'display:block' : 'display:none'%>">

--- a/app/views/recurring_todos/index.html.erb
+++ b/app/views/recurring_todos/index.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class="container" id="completed_recurring_todos_container">
-    <div class="add_note_link"><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
+    <div class="link_in_container_header"><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
     <h2><%= t('common.last') %> <%= t('todos.completed_recurring') %></h2>
     <div id="completed_recurring_todos_container">
       <div id="completed-empty-nd" style="<%= @no_completed_recurring_todos ? 'display:block' : 'display:none'%>">

--- a/app/views/stats/done.html.erb
+++ b/app/views/stats/done.html.erb
@@ -1,6 +1,6 @@
 <div id="display_box">
   <div class="container">
-    <div class=add_note_link><%= link_to t('common.show_all'), done_todos_path%></div>
+    <div class="add_note_link"><%= link_to t('common.show_all'), done_todos_path%></div>
     <h2>
       <%= t('common.last') %> <%= t('states.completed_plural' )%> <%= t('common.actions') %>
     </h2>
@@ -12,7 +12,7 @@
   </div>
 
   <div class="container">
-    <div class=add_note_link><%= link_to t('common.show_all'), done_projects_path%></div>
+    <div class="add_note_link"><%= link_to t('common.show_all'), done_projects_path%></div>
     <h2>
       <%= t('common.last') %> <%= t('states.completed_plural' )%> <%= t('common.projects') %>
     </h2>
@@ -29,7 +29,7 @@
   </div>
 
   <div class="container">
-    <div class=add_note_link><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
+    <div class="add_note_link"><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
     <h2>
       <%= t('common.last') %> <%= t('states.completed_plural' )%> <%= t('common.recurring_todos') %>
     </h2>

--- a/app/views/stats/done.html.erb
+++ b/app/views/stats/done.html.erb
@@ -1,6 +1,6 @@
 <div id="display_box">
   <div class="container">
-    <div class="add_note_link"><%= link_to t('common.show_all'), done_todos_path%></div>
+    <div class="link_in_container_header"><%= link_to t('common.show_all'), done_todos_path%></div>
     <h2>
       <%= t('common.last') %> <%= t('states.completed_plural' )%> <%= t('common.actions') %>
     </h2>
@@ -12,7 +12,7 @@
   </div>
 
   <div class="container">
-    <div class="add_note_link"><%= link_to t('common.show_all'), done_projects_path%></div>
+    <div class="link_in_container_header"><%= link_to t('common.show_all'), done_projects_path%></div>
     <h2>
       <%= t('common.last') %> <%= t('states.completed_plural' )%> <%= t('common.projects') %>
     </h2>
@@ -29,7 +29,7 @@
   </div>
 
   <div class="container">
-    <div class="add_note_link"><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
+    <div class="link_in_container_header"><%= link_to t('common.show_all'), done_recurring_todos_path%></div>
     <h2>
       <%= t('common.last') %> <%= t('states.completed_plural' )%> <%= t('common.recurring_todos') %>
     </h2>

--- a/app/views/todos/all_done.html.erb
+++ b/app/views/todos/all_done.html.erb
@@ -1,6 +1,6 @@
 <%
   paginate_options = {
-    :class => :add_note_link,
+    :class => 'link_in_container_header',
     :previous_label => '&laquo; '+ t('common.previous'),
     :next_label     => t('common.next')+' &raquo;',
     :inner_window   => 2


### PR DESCRIPTION
The code triggering the "new note" form is connected to the CSS class 'add_note_link', which was used all over the place for links inside the headers of (div) containers.

Fix #1851