### PR TITLE
(2.4) in tag view, do not use more-or-less random context for the form

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -635,9 +635,6 @@ class TodosController < ApplicationController
 
     # Set defaults for new_action
     @initial_tags = @tag_name
-    unless @not_done_todos.empty?
-      @context = current_user.contexts.find(@not_done_todos.first.context_id)
-    end
 
     # Set count badge to number of items with this tag
     @not_done_todos.empty? ? @count = 0 : @count = @not_done_todos.size


### PR DESCRIPTION
In the tag view (including starred) use the first (active) context in the form, based on the order of contexts as defined by the user. Picking the context of the oldest tagged (starred) action is not meaningful.

Fix #1834 