### PR TITLE
(2.3) in tag view, do not use more-or-less random context for the form

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -639,9 +639,6 @@ class TodosController < ApplicationController
 
     # Set defaults for new_action
     @initial_tags = @tag_name
-    unless @not_done_todos.empty?
-      @context = current_user.contexts.find(@not_done_todos.first.context_id)
-    end
 
     # Set count badge to number of items with this tag
     @not_done_todos.empty? ? @count = 0 : @count = @not_done_todos.size


### PR DESCRIPTION
Fix #1834, applies to 2.3