### PR TITLE
(2.3) Provide data needed for partial views

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -425,6 +425,8 @@ class TodosController < ApplicationController
 
     @saved = @todo.save
 
+    provide_project_or_context_for_view
+
     # this is set after save and cleared after reload, so save it here
     @removed_predecessors = @todo.removed_predecessors
 
@@ -454,6 +456,15 @@ class TodosController < ApplicationController
           render :action => "edit", :format => :m
         end
       end
+    end
+  end
+
+  def provide_project_or_context_for_view
+    # see application_helper:source_view_key, used in shown partials
+    if source_view_is :project
+      @project = @todo.project
+    elsif source_view_is :context
+      @context = @todo.context
     end
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1137,7 +1137,7 @@ end
   end
 
   def update_project
-    @project_changed = false;
+    @project_changed = false
     if params['todo']['project_id'].blank? && !params['project_name'].nil?
       if params['project_name'] == 'None'
         project = Project.null_object

--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -513,7 +513,7 @@ module TodosHelper
   def update_needs_to_remove_todo_from_container
     source_view do |page|
       page.context  { return @context_changed || @todo_deferred_state_changed || @todo_pending_state_changed || @todo_should_be_hidden }
-      page.project  { return @todo_deferred_state_changed || @todo_pending_state_changed || @project_changed}
+      page.project  { return @context_changed || @todo_deferred_state_changed || @todo_pending_state_changed || @project_changed}
       page.deferred { return todo_moved_out_of_container || !(@todo.deferred? || @todo.pending?) }
       page.calendar { return @due_date_changed || !@todo.due }
       page.stats    { return @todo.completed? }
@@ -547,7 +547,7 @@ module TodosHelper
   def append_updated_todo
     source_view do |page|
       page.context  { return @todo_deferred_state_changed || @todo_pending_state_changed }
-      page.project  { return @todo_deferred_state_changed || @todo_pending_state_changed }
+      page.project  { return @context_changed || @todo_deferred_state_changed || @todo_pending_state_changed }
       page.deferred { return todo_moved_out_of_container && (@todo.deferred? || @todo.pending?) }
       page.calendar { return @due_date_changed && @todo.due }
       page.stats    { return false }

--- a/app/views/todos/destroy.js.erb
+++ b/app/views/todos/destroy.js.erb
@@ -28,7 +28,7 @@ function show_empty_messages() {
 }
 
 function remove_todo_from_page() {
-  <% if (@remaining_in_context == 0) && update_needs_to_hide_container
+  <% if update_needs_to_hide_container
        # remove context with deleted todo
   -%>
        $('#<%=item_container_id(@todo)%>').fadeOut(400, function() {

--- a/app/views/todos/toggle_check.js.erb
+++ b/app/views/todos/toggle_check.js.erb
@@ -34,7 +34,7 @@ var <%= object_name %> = {
     redirect_to(path);
   },
   remove_todo: function(next_steps) {
-    <% if (@remaining_in_context == 0) && update_needs_to_hide_container
+    <% if update_needs_to_hide_container
       # remove context with deleted todo
     -%>
       $('#<%= item_container_id(@original_item)%>').slideUp(400, function() {

--- a/features/edit_a_todo.feature
+++ b/features/edit_a_todo.feature
@@ -326,7 +326,7 @@ Feature: Edit a next action from every page
     Given I have a deferred todo "moving" in context "@pc" with tags "tag"
     When I go to the tickler page
     And I edit the context of "moving" to "@new"
-    And I should see the container for context "@new"
+    Then I should see the container for context "@new"
 
   @javascript
   Scenario: Making an error when editing a todo will show error message

--- a/features/edit_a_todo.feature
+++ b/features/edit_a_todo.feature
@@ -329,6 +329,13 @@ Feature: Edit a next action from every page
     Then I should see the container for context "@new"
 
   @javascript
+  Scenario: Editing the context of a todo in the project view to a new context will show new context
+    Given I have a todo "something" in the context "@pc" in the project "project"
+    When I go to the "project" project page
+    And I edit the context of "something" to "@new"
+    Then I should see the container for context "@new"
+
+  @javascript
   Scenario: Making an error when editing a todo will show error message
     Given I have a todo "test"
     When I go to the home page


### PR DESCRIPTION
We need to have `@project`/`@context` for the corresponding partial views. This was not provided when editing an existing action.

Furthermore, the JavaScript now also removes and re-adds an action when the context was changed, so that it appears in the correct container.

Fixes #1836 and #1804 