### PR TITLE
(2.3) remove context if name is not set in update form

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -337,6 +337,8 @@ class ProjectsController < ApplicationController
     if default_context_name.present?
       default_context = current_user.contexts.where(:name => default_context_name).first_or_create
       p['default_context_id'] = default_context.id
+    else
+      p['default_context_id'] = nil
     end
   end
 


### PR DESCRIPTION
Fix #1839 