### PR TITLE
(2.3) Circular dependencies

### DIFF
--- a/app/assets/javascripts/tracks.js.erb
+++ b/app/assets/javascripts/tracks.js.erb
@@ -301,7 +301,6 @@ var TodoItems = {
         /* Drag & Drop for successor/predecessor */
         var dragged_todo = ui.draggable[0].id.split('_')[2];
         var dropped_todo = this.id.split('_')[2];
-        ui.draggable.remove();
         $('.drop_target').hide(); // IE8 doesn't call stop() in this situation
 
         ajax_options = default_ajax_options_for_scripts('POST', relative_to_root('todos/add_predecessor'), $(this));
@@ -324,7 +323,7 @@ var TodoItems = {
     setup_drag_and_drop: function() {
         $('.item-show').draggable({
             handle: '.grip',
-            revert: 'invalid',
+            revert: true,
             start: TodoItems.drag_todo,
             stop: function() {
                 $('.drop_target').hide();

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -85,7 +85,7 @@ class TodosController < ApplicationController
       create_multiple
     else
       p = Todos::TodoCreateParamsHelper.new(params, current_user)
-      p.parse_dates() unless mobile?
+      p.parse_dates unless mobile?
       tag_list = p.tag_list
 
       @todo = current_user.todos.build
@@ -1137,7 +1137,7 @@ end
   end
 
   def update_project
-    @project_changed = false;
+    @project_changed = false
     if params['todo']['project_id'].blank? && !params['project_name'].nil?
       if params['project_name'] == 'None'
         project = Project.null_object

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -423,7 +423,16 @@ class TodosController < ApplicationController
     update_dependencies
     update_attributes_of_todo
 
-    @saved = @todo.save
+    begin
+      @saved = @todo.save!
+    rescue ActiveRecord::RecordInvalid => exception
+      record = exception.record
+      if record.is_a?(Dependency)
+        record.errors.each { |key,value| @todo.errors[key] << value }
+      end
+      @saved = false
+    end
+
 
     # this is set after save and cleared after reload, so save it here
     @removed_predecessors = @todo.removed_predecessors


### PR DESCRIPTION
Fix two issues already mentioned in pull request #1777. This should be added, as #1777 is imcomplete/buggy without. Also relevant for release of 2.3.

1) Drag-n-drop removes the dragged todo if adding the dependency fails.
2) Adding a dependency does not show any error message in the edit form.

Fixes #1754.