### PR TITLE
(2.3) Update project name and context name in 'new action' form

### DIFF
--- a/app/assets/javascripts/tracks.js.erb
+++ b/app/assets/javascripts/tracks.js.erb
@@ -13,9 +13,6 @@ var TracksForm = {
         }
         toggleLink.parent().toggleClass('hide_form');
     },
-    set_project_name: function (name) {
-        $('input#todo_project_name').val(name);
-    },
     set_project_name_for_multi_add: function (name) {
         $('#multi_todo_project_name').val(name);
     },
@@ -30,9 +27,8 @@ var TracksForm = {
         $('input[name=default_context_name]').val(name);
     },
     set_project_name_and_default_project_name: function (name) {
-        TracksForm.set_project_name('');
+        $('input#todo_project_name').val(name);
         $('#default_project_name_id').val(name);
-        $('#project_name').html(name);
     },
     set_tag_list_and_default_tag_list: function (name) {
         $('input#tag_list').val(name);

--- a/app/assets/javascripts/tracks.js.erb
+++ b/app/assets/javascripts/tracks.js.erb
@@ -659,7 +659,7 @@ var ContextListPage = {
         $.post(relative_to_root('contexts/'+context_id), {
             'context[name]': value,
             '_method': 'put'
-        }, highlight);
+        }, highlight, 'script');
         return value;
     },
     setup_behavior: function() {

--- a/app/views/contexts/update.js.erb
+++ b/app/views/contexts/update.js.erb
@@ -18,6 +18,7 @@ var <%=object_name%> = {
       <% else -%>
         <%=object_name%>.replace_context_form_with_updated_context();
       <% end -%>
+      TracksForm.set_context_name("<%= escape_javascript(@context.name)%>");
     },
     remove_and_re_add_context: function() {
       $('#<%=dom_id(@context, 'container')%>').slideUp(500, function() {

--- a/app/views/contexts/update.js.erb
+++ b/app/views/contexts/update.js.erb
@@ -18,7 +18,7 @@ var <%=object_name%> = {
       <% else -%>
         <%=object_name%>.replace_context_form_with_updated_context();
       <% end -%>
-      TracksForm.set_context_name("<%= escape_javascript(@context.name)%>");
+      TracksForm.set_context_name_and_default_context_name("<%= escape_javascript(@context.name)%>");
     },
     remove_and_re_add_context: function() {
       $('#<%=dom_id(@context, 'container')%>').slideUp(500, function() {

--- a/app/views/projects/update.js.erb
+++ b/app/views/projects/update.js.erb
@@ -34,7 +34,7 @@ var <%=object_name%> = {
     update_project_page: function() {
       <%=object_name%>.remove_project_edit_form();
       <%=object_name%>.update_and_show_project_settings();
-      TracksForm.set_project_name("<%= escape_javascript(@project.name)%>");
+      TracksForm.set_project_name_and_default_project_name("<%= escape_javascript(@project.name)%>");
       $("h2 span#project_name").html("<%= escape_javascript(@project.name)%>");
       <% if @project.default_context %>
         TracksForm.set_context_name_and_default_context_name("<%= escape_javascript(@project.default_context.name)%>");

--- a/app/views/projects/update_project_name.js.erb
+++ b/app/views/projects/update_project_name.js.erb
@@ -1,4 +1,4 @@
 <% if @saved -%>
   TracksPages.page_inform('<%=t('projects.status_project_name_changed')%>');
-  TracksForm.set_project_name("<%= escape_javascript(@project.name)%>");
+  TracksForm.set_project_name_and_default_project_name("<%= escape_javascript(@project.name)%>");
 <% end %>

--- a/app/views/todos/create.js.erb
+++ b/app/views/todos/create.js.erb
@@ -28,7 +28,7 @@
     $('#todo-form-new-action').clearForm();
     $('#todo-form-new-action').clearDeps();
     TracksForm.set_context_name('<%=escape_javascript @initial_context_name%>');
-    TracksForm.set_project_name('<%=escape_javascript @initial_project_name%>');
+    TracksForm.set_project_name_and_default_project_name('<%=escape_javascript @initial_project_name%>');
     TracksForm.set_tag_list_and_default_tag_list('<%=escape_javascript @initial_tags%>');
     $('#todo-form-new-action input:text:first').focus();
     $('#new_todo_starred_link .todo_star').removeClass('starred');

--- a/features/context_edit.feature
+++ b/features/context_edit.feature
@@ -21,6 +21,13 @@ Feature: Edit a context
     Then I should see that a context named "Errands" is not present
     And I should see that a context named "OutAndAbout" is present
 
+  # Ticket #1796
+  @javascript
+  Scenario: I can change the name of the context and it should update the new todo form
+    When I go to the context page for "@pc"
+    And I edit the context name in place to be "OutAndAbout"
+    Then the context field of the new todo form should contain "OutAndAbout"
+
   @javascript
   Scenario: Editing the context of a todo will remove the todo
     When I go to the the context page for "@pc"

--- a/features/context_edit.feature
+++ b/features/context_edit.feature
@@ -28,6 +28,14 @@ Feature: Edit a context
     And I edit the context name in place to be "OutAndAbout"
     Then the context field of the new todo form should contain "OutAndAbout"
 
+  # Ticket #1789
+  @javascript
+  Scenario: I can change the name of the context and it should still allow me to add new actions
+    When I go to the context page for "@pc"
+    And I edit the context name in place to be "OutAndAbout"
+    And I submit a new action with description "a new next action"
+    Then I should see the todo "a new next action"
+
   @javascript
   Scenario: Editing the context of a todo will remove the todo
     When I go to the the context page for "@pc"

--- a/features/project_edit.feature
+++ b/features/project_edit.feature
@@ -58,6 +58,16 @@ Feature: Edit a project
     Then the project title should be "cherries"
     And the project field of the new todo form should contain "cherries"
 
+  # Ticket #1789
+  @javascript
+  Scenario: I can change the name of the project and it should still allow me to add new actions
+    Given I have a project "bananas"
+    When I go to the "bananas" project
+    And I edit the project name to "cherries"
+    And I edit the default context to "@pc"
+    And I submit a new action with description "a new next action"
+    Then I should see the todo "a new next action"
+
   @javascript
   Scenario: I can change the default context of the project and it should update the new todo form
     Given I have a project "bananas" with 1 todos

--- a/features/step_definitions/context_steps.rb
+++ b/features/step_definitions/context_steps.rb
@@ -54,6 +54,7 @@ When /^I edit the context name in place to be "([^\"]*)"$/ do |new_context_name|
   page.find("span#context_name").click
   fill_in "value", :with => new_context_name
   click_button "Ok"
+  wait_for_ajax
 end
 
 Then /^I should see the context name is "([^\"]*)"$/ do |context_name|

--- a/features/step_definitions/todo_steps.rb
+++ b/features/step_definitions/todo_steps.rb
@@ -119,6 +119,11 @@ Then /^the project field of the new todo form should contain "([^"]*)"$/ do |pro
   expect(project_name).to eq(page.find(:xpath, xpath).value)
 end
 
+Then /^the context field of the new todo form should contain "([^"]*)"$/ do |context_name|
+  xpath= "//form[@id='todo-form-new-action']/input[@id='todo_context_name']"
+  expect(page.find(:xpath, xpath).value).to eq(context_name)
+end
+
 Then /^the default context of the new todo form should be "([^"]*)"$/ do |context_name|
   xpath= "//form[@id='todo-form-new-action']/input[@id='todo_context_name']"
   expect(context_name).to eq(page.find(:xpath, xpath).value)


### PR DESCRIPTION
When adding a new action in the project view, after changing the project's name we need to set a hidden field in the form so that the updated project is used for new actions.

The same holds for the context view, where we need to update another hidden field after changing a context's name.

This fixes #1789.

In addition, this fixes #1796 by updating the context in the visible part of the form after changing the context's name in the context view.