### PR TITLE
Activate successors on predecessor destroy

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -494,13 +494,10 @@ class TodosController < ApplicationController
       @uncompleted_predecessors << predecessor
     end
 
-    # activate successors if they only depend on this todo
     activated_successor_count = 0
     @pending_to_activate = []
     @todo.pending_successors.each do |successor|
-      successor.uncompleted_predecessors.delete(@todo)
-      if successor.uncompleted_predecessors.empty?
-        successor.activate!
+      if successor.uncompleted_predecessors.size == 1
         @pending_to_activate << successor
         activated_successor_count += 1
       end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -408,4 +408,16 @@ class Todo < ActiveRecord::Base
     count
   end
 
+  def destroy
+    # activate successors if they only depend on this action
+    self.pending_successors.each do |successor|
+      successor.uncompleted_predecessors.delete(self)
+      if successor.uncompleted_predecessors.empty?
+        successor.activate!
+      end
+    end
+
+    super
+  end
+
 end

--- a/test/models/todo_test.rb
+++ b/test/models/todo_test.rb
@@ -542,4 +542,14 @@ class TodoTest < ActiveSupport::TestCase
     assert_equal "<p><strong>test</strong></p>", todo.rendered_notes
   end
 
+  def test_destroying_action_activates_successors
+    @not_completed1.add_predecessor(@not_completed2)
+    @not_completed1.block!
+
+    @not_completed2.destroy
+
+    @not_completed1.reload
+    assert @not_completed1.active?
+  end
+
 end


### PR DESCRIPTION
Move the activation code to the model, so that it also is used when converting an action into a project.

Fixes #1881