### PR TITLE
Provide minimum version for sanitize gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "sqlite3", group: :sqlite
 gem "mysql2", group: :mysql
 
 gem "RedCloth"
-gem "sanitize"
+gem "sanitize", ">=3.0.0"
 gem "will_paginate"
 gem "acts_as_list"
 gem "aasm"


### PR DESCRIPTION
The sanitize code in Tracks uses merge to copy Sanitize configurations,
but this was only introduced in version 3.0.0.