### PR TITLE
Increase the usability of the new todo mobile view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     hike (1.2.3)
     htmlentities (4.3.3)
     i18n (0.7.0)
-    jquery-rails (3.1.2)
+    jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
@@ -112,7 +112,7 @@ GEM
       mini_portile (~> 0.6.0)
     nokogumbo (1.1.12)
       nokogiri
-    rack (1.5.4)
+    rack (1.5.5)
     rack-dev-mark (0.7.3)
       rack (>= 1.1)
     rack-mini-profiler (0.9.2)

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -295,7 +295,7 @@ div.note_wrapper p {
 }
 
 .btn {
-    padding: 8px 8px;
+    padding: 8px;
     border-radius: 5px;
     background-image: none;
     display: inline-block;

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -302,5 +302,5 @@ div.note_wrapper p {
     white-space: none;
     border: 1px solid transparent;
     background-color: #999999;
-    color: white;
+    color: #ffffff;
 }

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -236,6 +236,7 @@ table.c {
 
 input#todo_description, input#tag_list, textarea#todo_notes, select#todo_project_id, select#todo_context_id {
     width: 95%;
+    padding: 8px 8px;
 }
 
 .next-prev-project {

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -295,13 +295,12 @@ div.note_wrapper p {
 }
 
 .btn {
-  padding: 8px 8px;
-  border-radius: 5px;
-  background-image: none;
-  display: inline-block;
-  white-space: none;
-  border: 1px solid transparent;
-  background-color: #999999;
-  color: white;
+    padding: 8px 8px;
+    border-radius: 5px;
+    background-image: none;
+    display: inline-block;
+    white-space: none;
+    border: 1px solid transparent;
+    background-color: #999999;
+    color: white;
 }
-

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -239,6 +239,10 @@ input#todo_description, input#tag_list, textarea#todo_notes, select#todo_project
     padding: 8px 8px;
 }
 
+select {
+  font-size: 1.1em;
+}
+
 .next-prev-project {
     overflow:auto;
     padding:0;

--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -289,3 +289,14 @@ div.note_wrapper p {
     text-align: right;
 }
 
+.btn {
+  padding: 8px 8px;
+  border-radius: 5px;
+  background-image: none;
+  display: inline-block;
+  white-space: none;
+  border: 1px solid transparent;
+  background-color: #999999;
+  color: white;
+}
+

--- a/app/views/todos/edit.m.erb
+++ b/app/views/todos/edit.m.erb
@@ -1,5 +1,5 @@
 <%= form_tag todo_path(@todo, :format => 'm'), :name => 'mobileEdit', :method => :put do %>
   <%= render :partial => 'edit_form', :locals => { :parent_container_type => "show_mobile" } %>
-  <p><input type="submit" value="<%= t('common.update') %>" tabindex="6" accesskey="#" /></p>
+  <p><input type="submit" value="<%= t('common.update') %>" tabindex="6" accesskey="#" class="btn"/></p>
 <% end -%>
 <%= link_to t('common.cancel'), @return_path %>

--- a/app/views/todos/new.m.erb
+++ b/app/views/todos/new.m.erb
@@ -1,6 +1,6 @@
 <%= form_tag todos_path(:format => 'm'), :method => :post do %>
   <%= render :partial => 'edit_form' %>
-  <p class="text-right"><input type="submit" value="<%= t('common.create') %>" tabindex="12" accesskey="#" /></p>
+  <p class="text-right"><input type="submit" class="btn" value="<%= t('common.create') %>" tabindex="12" accesskey="#" /></p>
 <% end -%>
 <%= link_to t('common.back'), @return_path %>
 

--- a/app/views/todos/show.m.erb
+++ b/app/views/todos/show.m.erb
@@ -4,42 +4,42 @@
 <h2><Actions><%= t('common.actions') %></h2>
 
 <form method="get" action="<%= edit_todo_path(@todo, :format => :m)%>">
-	<button><%=t('todos.edit_action')%></button>
+	<button class="btn"><%=t('todos.edit_action')%></button>
 	<input type="hidden" name="_method" value="put" />
 </form>
 
 <form method="post" action="<%=toggle_star_todo_path(@todo, :format=>:m)%>">
-	<button><%=t('todos.star_action')%></button>
+	<button class="btn"><%=t('todos.star_action')%></button>
 	<input type="hidden" name="_method" value="put" />
 	<%= token_tag %>
 </form>
 
 <form method="post" action="<%=toggle_check_todo_path(@todo, :format=>:m)%>">
-	<button><%= t('todos.mark_complete')%></button>
+	<button class="btn"><%= t('todos.mark_complete')%></button>
 	<input type="hidden" name="_method" value="put" />
 	<%= token_tag %>
 </form>
 
 <form method="post" action="<%=defer_todo_path(@todo, :format=>:m, :days => 1)%>">
-	<button><%=t('todos.defer_x_days', :count => 1)%></button>
+	<button class="btn"><%=t('todos.defer_x_days', :count => 1)%></button>
 	<input type="hidden" name="_method" value="put" />
 	<%= token_tag %>
 </form>
 
 <form method="post" action="<%=defer_todo_path(@todo, :format=>:m, :days => 2)%>">
-	<button><%=t('todos.defer_x_days', :count => 2)%></button>
+	<button class="btn"><%=t('todos.defer_x_days', :count => 2)%></button>
 	<input type="hidden" name="_method" value="put" />
 	<%= token_tag %>
 </form>
 
 <form method="post" action="<%=defer_todo_path(@todo, :format=>:m, :days => 3)%>">
-	<button><%=t('todos.defer_x_days', :count => 3)%></button>
+	<button class="btn"><%=t('todos.defer_x_days', :count => 3)%></button>
 	<input type="hidden" name="_method" value="put" />
 	<%= token_tag %>
 </form>
 
 <form method="post" action="<%=defer_todo_path(@todo, :format=>:m, :days => 7)%>">
-	<button><%=t('todos.defer_x_days', :count => 7)%></button>
+	<button class="btn"><%=t('todos.defer_x_days', :count => 7)%></button>
 	<input type="hidden" name="_method" value="put" />
 	<%= token_tag %>
 </form>


### PR DESCRIPTION
Entering new todos is somewhat painful. This set of changes increases the usability of the new todo mobile UI by enlarging elements to make them easier to hit.

Here's a screenshot of what these changes look like on a phone:

![ios simulator screen shot jul 24 2015 10 42 25 pm](https://cloud.githubusercontent.com/assets/77174/8887764/d994d9da-3255-11e5-9835-516d183c2039.png)
