### PR TITLE
Use box-sizing: border-box to style mobile input

### DIFF
--- a/app/assets/stylesheets/mobile.css.scss
+++ b/app/assets/stylesheets/mobile.css.scss
@@ -235,8 +235,9 @@ table.c {
 }
 
 input#todo_description, input#tag_list, textarea#todo_notes, select#todo_project_id, select#todo_context_id {
-    width: 95%;
+    width: 100%;
     padding: 8px 8px;
+    box-sizing: border-box;
 }
 
 select {


### PR DESCRIPTION
Hi @mattr-,

I've tried your PR and I like it! I've just noticed that adding this commit you can better style the input fields in order to have a consistent left/right margin.

We could better organise the date select with flexbox, but I don't know if it's a problem to use it, even if only on mobile (http://caniuse.com/#feat=flexbox).