### PR TITLE
Fix failing tests for non-UTC timezones

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1071,10 +1071,10 @@ end
       if recurring_todo.todos.active.count == 0
 
         # check for next todo either from the due date or the show_from date
-        date_to_check = todo.due.nil? ? todo.show_from : todo.due
+        date_to_check = todo.due || todo.show_from
 
         # if both due and show_from are nil, check for a next todo from now
-        date_to_check = Time.zone.now if date_to_check.nil?
+        date_to_check ||= Time.zone.now
 
         if recurring_todo.active? && recurring_todo.continues_recurring?(date_to_check)
 
@@ -1087,7 +1087,7 @@ end
           # for tomorrow.
           date = date_to_check.at_midnight >= Time.zone.now.at_midnight ? date_to_check : Time.zone.now-1.day
 
-          new_recurring_todo = TodoFromRecurringTodo.new(current_user, recurring_todo).create(date.at_midnight)
+          new_recurring_todo = TodoFromRecurringTodo.new(current_user, recurring_todo).create(date)
         end
       end
     end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -5,7 +5,7 @@ module StatsHelper
   end
 
   def month_and_year_label(i)
-    t('date.month_names')[ (Time.now.mon - i -1 ) % 12 + 1 ]+ " " + (Time.now - i.months).year.to_s
+    t('date.month_names')[ (Time.zone.now.mon - i -1 ) % 12 + 1 ]+ " " + (Time.zone.now - i.months).year.to_s
   end
 
   def array_of_month_and_year_labels(count)
@@ -13,7 +13,7 @@ module StatsHelper
   end
 
   def month_label(i)
-    t('date.month_names')[ (Time.now.mon - i -1 ) % 12 + 1 ]
+    t('date.month_names')[ (Time.zone.now.mon - i -1 ) % 12 + 1 ]
   end
 
   def array_of_month_labels(count)

--- a/app/models/recurring_todos/abstract_recurrence_pattern.rb
+++ b/app/models/recurring_todos/abstract_recurrence_pattern.rb
@@ -151,7 +151,7 @@ module RecurringTodos
     end
 
     def get_next_date(previous)
-      raise "Should not call AbstractRecurrencePattern.get_next_date directly. Overwrite in subclass"
+      raise "Should not call AbstractRecurrencePattern.get_next_date directly. Override in subclass"
     end
 
     def continues_recurring?(previous)
@@ -174,13 +174,13 @@ module RecurringTodos
     # same day as the previous
     def determine_start(previous, offset=0.day)
       start = self.start_from || NullTime.new
-      now = Time.zone.now
       if previous
         # check if the start_from date is later than previous. If so, use
         # start_from as start to search for next date
         start > previous ? start : previous + offset
       else
         # skip to present
+        now = Time.zone.now
         start > now ? start : now
       end
     end
@@ -199,32 +199,24 @@ module RecurringTodos
     end
 
     def find_last_day_x_of_month(weekday, month, year)
-      # count backwards. use UTC to avoid strange timezone oddities
-      # where last_day -= 1.day seems to shift tz+0100 to tz+0000
-      last_day = Time.utc(year, month, Time.days_in_month(month))
+      last_day = Time.zone.local(year, month, Time.days_in_month(month))
       while last_day.wday != weekday
         last_day -= 1.day
       end
-      # convert back to local timezone
-      Time.zone.local(last_day.year, last_day.month, last_day.day)
+      last_day
     end
 
     def find_xth_day_of_month(x, weekday, month, year)
-      # 1-4th -> count upwards last -> count backwards. use UTC to avoid strange
-      # timezone oddities where last_day -= 1.day seems to shift tz+0100 to
-      # tz+0000
-      start = Time.utc(year,month,1)
+      start = Time.zone.local(year,month,1)
       n = x
       while n > 0
         while start.wday() != weekday
-          start+= 1.day
+          start += 1.day
         end
         n -= 1
-        start+= 1.day unless n==0
+        start += 1.day unless n==0
       end
-      # convert back to local timezone
-      Time.zone.local(start.year, start.month, start.day)
+      start
     end
-
   end
 end

--- a/app/models/recurring_todos/monthly_recurrence_pattern.rb
+++ b/app/models/recurring_todos/monthly_recurrence_pattern.rb
@@ -82,18 +82,9 @@ module RecurringTodos
     def find_specific_day_of_month(previous, start, n)
       if (previous && start.mday >= every_x_day) || (previous.nil? && start.mday > every_x_day)
         # there is no next day n in this month, search in next month
-        #
-        #  start += n.months
-        #
-        # The above seems to not work. Fiddle with timezone. Looks like we hit a
-        # bug in rails here where 2008-12-01 +0100 plus 1.month becomes
-        # 2008-12-31 +0100. For now, just calculate in UTC and convert back to
-        # local timezone.
-        #
-        #  TODO: recheck if future rails versions have this problem too
-        start = Time.utc(start.year, start.month, start.day)+n.months
+        start += n.months
       end
-      Time.zone.local(start.year, start.month, every_x_day)
+      start.in_time_zone.change(day: every_x_day)
     end
 
     def find_relative_day_of_month(start, n)
@@ -101,13 +92,7 @@ module RecurringTodos
       if the_next.nil? || the_next <= start
         # the nth day is already passed in this month, go to next month and try
         # again
-
-        # fiddle with timezone. Looks like we hit a bug in rails here where
-        # 2008-12-01 +0100 plus 1.month becomes 2008-12-31 +0100. For now, just
-        # calculate in UTC and convert back to local timezone.
-        #  TODO: recheck if future rails versions have this problem too
-        the_next = Time.utc(the_next.year, the_next.month, the_next.day)+n.months
-        the_next = Time.zone.local(the_next.year, the_next.month, the_next.day)
+        the_next += n.months
 
         # TODO: if there is still no match, start will be set to nil. if we ever
         # support 5th day of the month, we need to handle this case
@@ -136,7 +121,5 @@ module RecurringTodos
         day:      day_of_week_as_text(day_of_week),
         n_months: n_months)
     end
-
   end
-
 end

--- a/app/models/stats/totals.rb
+++ b/app/models/stats/totals.rb
@@ -19,7 +19,7 @@ module Stats
     end
 
     def first_action_at
-      first_action.created_at if first_action
+      first_action.try(:created_at)
     end
 
     def projects

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
           <% if @count -%>
             <span id="badge_count" class="badge"><%= @count %></span>
           <% end -%>
-          <%= l(Date.today, :format => current_user.prefs.title_date_format) %>
+          <%= l(Time.zone.today, :format => current_user.prefs.title_date_format) %>
         </h1>
       </div>
       <div id="minilinks">

--- a/app/views/layouts/mobile.m.erb
+++ b/app/views/layouts/mobile.m.erb
@@ -16,7 +16,7 @@
 </head><body>
 <% if current_user && !current_user.prefs.nil? -%>
 <div id="topbar"><h1><% if @down_count -%><span class="count" id="badge_count"><%= @down_count %></span><% end -%> <%=
-        l(Date.today, :format => current_user.prefs.title_date_format) -%></h1>
+        l(Time.zone.today, :format => current_user.prefs.title_date_format) -%></h1>
 <ul class="nav">
   <li class="link"><%=     (link_to(t('layouts.mobile_navigation.new_action'), new_todo_path(new_todo_params))) -%></li>
   <li class="link"><%=     (link_to(t('layouts.mobile_navigation.home'), todos_path(:format => 'm'))) -%></li>

--- a/app/views/preferences/_date_and_time.html.erb
+++ b/app/views/preferences/_date_and_time.html.erb
@@ -1,23 +1,22 @@
 <%= pref_with_text_field('prefs', 'date_format') %>
 
-<div class='prefs_example'>This will result in: <span id='prefs.date_format'><%= l(Date.today, :format => current_user.prefs.date_format) %></span></div>
+<div class='prefs_example'>This will result in: <span id='prefs.date_format'><%= l(Time.zone.today, :format => current_user.prefs.date_format) %></span></div>
 <br/>
 Or pick one of the following:<br/>
 <% %w{default short long longer}.each do |format| %>
-<%= radio_button_tag("date_picker1", t("date.formats.#{format}")) %> <%= l(Date.today, :format => format.to_sym) %> <br/>
+<%= radio_button_tag("date_picker1", t("date.formats.#{format}")) %> <%= l(Time.zone.today, :format => format.to_sym) %> <br/>
 <% end %>
 <br/>
 
 <%= pref_with_text_field('prefs', 'title_date_format') %>
-<div class='prefs_example'>This will result in: <span id='prefs.title_date_format'><%= l(Date.today, :format => current_user.prefs.title_date_format) %></span></div>
+<div class='prefs_example'>This will result in: <span id='prefs.title_date_format'><%= l(Time.zone.today, :format => current_user.prefs.title_date_format) %></span></div>
 <br/>
 Or pick one of the following:<br/>
 <% %w{default short long longer}.each do |format| %>
-<%= radio_button_tag("date_picker2", t("date.formats.#{format}")) %> <%= l(Date.today, :format => format.to_sym) %> <br/>
+<%= radio_button_tag("date_picker2", t("date.formats.#{format}")) %> <%= l(Time.zone.today, :format => format.to_sym) %> <br/>
 <% end %>
 <br/>
 
 <%= pref('prefs', 'time_zone') { time_zone_select('prefs','time_zone') } %>
 
 <%= pref_with_select_field('prefs', "week_starts", (0..6).to_a.map {|num| [t('date.day_names')[num], num] }) %>
-

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,10 +30,10 @@ module Tracksapp
 
     # configure Tracks to handle deployment in a subdir
     config.relative_url_root = SITE_CONFIG['subdir'] if SITE_CONFIG['subdir']
-    
+
     # allow onenote:// and message:// as protocols for urls
     config.action_view.sanitized_allowed_protocols = 'onenote', 'message'
-    
+
     config.middleware.insert_after ActionDispatch::ParamsParser, ActionDispatch::XmlParamsParser
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,8 +34,6 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  config.time_zone = 'UTC'
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/lib/todo_from_recurring_todo.rb
+++ b/lib/todo_from_recurring_todo.rb
@@ -27,7 +27,7 @@ class TodoFromRecurringTodo
   end
 
   def end_date
-    todo.due ? todo.due : todo.show_from
+    todo.due || todo.show_from
   end
 
   def attributes

--- a/test/controllers/recurring_todos_controller_test.rb
+++ b/test/controllers/recurring_todos_controller_test.rb
@@ -184,7 +184,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
 
     # mark as active
     xhr :post, :toggle_check, :id=>1, :_source_view=>""
-    
+
     recurring_todo_1 = RecurringTodo.find(1) # reload seems to not work
     assert recurring_todo_1.active?, "recurring todo should be active but is #{recurring_todo_1.aasm.current_state}"
 
@@ -203,7 +203,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
 
     # change due date in four days from now and show from 10 days before, i.e. 6
     # days ago
-    target_date = Time.now.utc + 4.days
+    target_date = Time.zone.now + 4.days
     @yearly.every_other1 = target_date.day
     @yearly.every_other2 = target_date.month
     @yearly.show_from_delta = 10
@@ -260,7 +260,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
         "recurring_show_days_before"=>"0",
         "recurring_target"=>"due_date",
         "recurring_show_always" => "1",
-        "start_from"=>"1/10/2012",  
+        "start_from"=>"1/10/2012",
         "weekly_every_x_week"=>"1",
         "weekly_return_monday"=>"w",
         "yearly_day_of_week"=>"0",
@@ -419,9 +419,9 @@ class RecurringTodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
     rt = recurring_todos(:call_bill_gates_every_day)
 
-    put :update, 
-      "recurring_todo" => { 
-        "description"        => "changed", 
+    put :update,
+      "recurring_todo" => {
+        "description"        => "changed",
         "daily_selector"     => "daily_every_x_day",
         "daily_every_x_days" => "2",
         "ends_on"            => "no_end_date",
@@ -433,7 +433,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
       "recurring_todo_edit_start_from" => "2/1/2013",
       "end_date"                       => nil,
       "ends_on"                        => "no_end_date",
-      "id"                             => "#{rt.id}", 
+      "id"                             => "#{rt.id}",
       "context_name"                   => "library",
       format: :js
 

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -120,7 +120,7 @@ class TodosControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 3, @tagged
   end
-  
+
   def test_find_tagged_with_terms_separated_with_dot
     login_as :admin_user
     create_todo(description: "test dotted tag", tag_list: "first.last, second")
@@ -408,7 +408,7 @@ class TodosControllerTest < ActionController::TestCase
 
   #######
   # defer
-  ####### 
+  #######
 
   def test_update_clearing_show_from_makes_todo_active
     t = Todo.find(1)
@@ -437,7 +437,7 @@ class TodosControllerTest < ActionController::TestCase
     # given a todo in the tickler that should be activated
     travel_to 2.weeks.ago do
       create_todo(
-        description: "tickler", 
+        description: "tickler",
         show_from: 1.week.from_now.
           in_time_zone(users(:admin_user).prefs.time_zone).
           strftime("#{users(:admin_user).prefs.date_format}"))
@@ -715,17 +715,25 @@ class TodosControllerTest < ActionController::TestCase
   end
 
   def test_toggle_check_on_rec_todo_show_from_today
+    # warning: the Time.zone set in site.yml will be overwritten by
+    # :admin_user.prefs.time_zone in ApplicationController. This messes with
+    # the calculation. So set time_zone to admin_user's time_zone setting
+    Time.zone = users(:admin_user).prefs.time_zone
+
     travel_to Time.zone.local(2014, 1, 15) do
+      today = Time.zone.now.at_midnight
+
       login_as(:admin_user)
 
       # link todo_1 and recurring_todo_1
       recurring_todo_1 = RecurringTodo.find(1)
       todo_1 = Todo.where(:recurring_todo_id => 1).first
-      today = Time.zone.now.at_midnight
       todo_1.due = today
       assert todo_1.save
 
-      # change recurrence pattern to monthly and set show_from to today
+      # change recurrence pattern to monthly on a specific
+      # day (recurrence_selector=0) and set show_from
+      # (every_other2=1) to today
       recurring_todo_1.target = 'show_from_date'
       recurring_todo_1.recurring_period = 'monthly'
       recurring_todo_1.recurrence_selector = 0
@@ -746,15 +754,13 @@ class TodosControllerTest < ActionController::TestCase
       assert_not_equal todo_1.id, new_todo.id, "check that the new todo is not the same as todo_1"
       assert !new_todo.show_from.nil?, "check that the new_todo is in the tickler to show next month"
 
-      # do not use today here. It somehow gets messed up with the timezone calculation.
-      next_month = (Time.zone.now + 1.month).at_midnight
-
-      assert_equal next_month.utc.to_date.to_s(:db), new_todo.show_from.utc.to_date.to_s(:db)
+      assert_equal today + 1.month, new_todo.show_from
     end
   end
 
   def test_check_for_next_todo
     login_as :admin_user
+    Time.zone = users(:admin_user).prefs.time_zone
 
     tomorrow = Time.zone.now + 1.day
 
@@ -791,6 +797,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_check_for_next_todo_monthly
     login_as :admin_user
+    Time.zone = users(:admin_user).prefs.time_zone
 
     tomorrow = Time.zone.now + 1.day
 
@@ -1024,13 +1031,13 @@ class TodosControllerTest < ActionController::TestCase
   private
 
   def create_todo(params={})
-    defaults = { source_view: 'todo', 
-      context_name: "library", project_name: "Build a working time machine", 
+    defaults = { source_view: 'todo',
+      context_name: "library", project_name: "Build a working time machine",
       notes: "note", description: "a new todo", due: nil, tag_list: "a,b,c"}
 
     params=params.reverse_merge(defaults)
 
-    put :create, _source_view: params[:_source_view], 
+    put :create, _source_view: params[:_source_view],
       context_name: params[:context_name], project_name: params[:project_name], tag_list: params[:tag_list],
       todo: {notes: params[:notes], description: params[:description], due: params[:due], show_from: params[:show_from]}
   end

--- a/test/fixtures/contexts.yml
+++ b/test/fixtures/contexts.yml
@@ -1,8 +1,11 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
-<% 
 
-def today 
-  Time.now.utc.to_s(:db) 
+# Please note that dates in yml are not converted to utc timezone like
+# rails does automatically in models or controllers! Convert to utc manually!
+<%
+
+def today
+  Time.zone.now.utc.to_s(:db)
 end
 
 %>

--- a/test/fixtures/notes.yml
+++ b/test/fixtures/notes.yml
@@ -1,16 +1,19 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
-<% 
-def today 
-  Time.now.utc.to_s(:db) 
+
+# Please note that dates in yml are not converted to utc timezone like
+# rails does automatically in models or controllers! Convert to utc manually!
+<%
+def today
+  Time.zone.now.utc.to_s(:db)
 end
- 
-def next_week 
-  1.week.from_now.utc.to_s(:db) 
+
+def next_week
+  1.week.from_now.utc.to_s(:db)
 end
- 
-def last_week 
-  1.week.ago.utc.to_s(:db) 
-end 
+
+def last_week
+  1.week.ago.utc.to_s(:db)
+end
 %>
 
 first_notes:

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,7 +1,10 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
+
+# Please note that dates in yml are not converted to utc timezone like
+# rails does automatically in models or controllers! Convert to utc manually!
 <%
-def today 
-  Time.zone.now.beginning_of_day.to_s(:db) 
+def today
+  Time.zone.now.utc.beginning_of_day.to_s(:db)
 end
 %>
 

--- a/test/fixtures/recurring_todos.yml
+++ b/test/fixtures/recurring_todos.yml
@@ -1,26 +1,29 @@
+# Please note that dates in yml are not converted to utc timezone like
+# rails does automatically in models or controllers! Convert to utc manually!
+
 <%
 def today
-    Time.zone.now.beginning_of_day.to_s(:db)
+    Time.zone.now.utc.beginning_of_day.to_s(:db)
 end
 
 def next_week
-    1.week.from_now.beginning_of_day.to_s(:db)
+    1.week.from_now.utc.beginning_of_day.to_s(:db)
 end
 
 def last_week
-    1.week.ago.beginning_of_day.to_s(:db)
+    1.week.ago.utc.beginning_of_day.to_s(:db)
 end
 
 def two_weeks_ago
-    2.weeks.ago.beginning_of_day.to_s(:db)
+    2.weeks.ago.utc.beginning_of_day.to_s(:db)
 end
 
 def two_weeks_hence
-    2.weeks.from_now.beginning_of_day.to_s(:db)
+    2.weeks.from_now.utc.beginning_of_day.to_s(:db)
 end
 
 def way_back
-  Time.zone.local(2008,1,1).to_s(:db)
+  Time.zone.local(2008,1,1).utc.to_s(:db)
 end
 
 %>

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,17 +1,27 @@
+# please note that dates in yml are not converted to utc timezone like
+# rails does automatically in models or controllers! Convert to utc manually!
+
+<%
+def today
+  Time.zone.now.utc.beginning_of_day.to_s(:db)
+end
+%>
+
 foo:
   id: 1
   name: foo
-  created_at: <%= Time.now.utc.to_s(:db) %>
-  updated_at: <%= Time.now.utc.to_s(:db) %>
+  created_at: <%= today %>
+  updated_at: <%= today %>
 
 bar:
   id: 2
   name: bar
-  created_at: <%= Time.now.utc.to_s(:db) %>
-  updated_at: <%= Time.now.utc.to_s(:db) %>
-  
+  created_at: <%= today %>
+  updated_at: <%= today %>
+
 baz:
   id: 3
   name: baz
-  created_at: <%= Time.now.utc.to_s(:db) %>
-  updated_at: <%= Time.now.utc.to_s(:db) %>
+  created_at: <%= today %>
+  updated_at: <%= today %>
+  

--- a/test/fixtures/todos.yml
+++ b/test/fixtures/todos.yml
@@ -1,26 +1,27 @@
 # Read about fixtures at http://ar.rubyonrails.org/classes/Fixtures.html
-<% 
 
-Time.zone = SITE_CONFIG['time_zone']
+# Please note that dates in yml are not converted to utc timezone like
+# rails does automatically in models or controllers! Convert to utc manually!
 
-def today 
-  Time.zone.now.beginning_of_day.to_s(:db)
+<%
+def today
+  Time.zone.now.utc.beginning_of_day.to_s(:db)
 end
 
-def next_week 
-  1.week.from_now.beginning_of_day.to_s(:db)
-end 
+def next_week
+  1.week.from_now.utc.beginning_of_day.to_s(:db)
+end
 
-def last_week 
-  1.week.ago.beginning_of_day.to_s(:db)
+def last_week
+  1.week.ago.utc.beginning_of_day.to_s(:db)
 end
 
 def two_weeks_ago
-  2.weeks.ago.beginning_of_day.to_s(:db)
+  2.weeks.ago.utc.beginning_of_day.to_s(:db)
 end
 
 def two_weeks_hence
-  2.weeks.from_now.beginning_of_day.to_s(:db)
+  2.weeks.from_now.utc.beginning_of_day.to_s(:db)
 end
 
 %>
@@ -192,7 +193,7 @@ call_stock_broker:
   due: ~
   completed_at: ~
   user_id: 1
-  
+
 select_delorean_model:
   id: 15
   context_id: 6
@@ -254,4 +255,3 @@ email_broker:
   description: Ask about better stocks
   notes: ~
   state: pending
-  

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -98,7 +98,7 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal :completed, @timemachine.aasm.current_state
     assert @timemachine.completed?
     assert_not_nil @timemachine.completed_at, "completed_at not expected to be nil"
-    assert_in_delta Time.now, @timemachine.completed_at, 1
+    assert_in_delta Time.zone.now, @timemachine.completed_at, 1
   end
 
   def test_delete_project_deletes_todos_within_it
@@ -254,5 +254,4 @@ class ProjectTest < ActiveSupport::TestCase
     p.reload
     assert_equal 4, p.running_time
   end
-
 end

--- a/test/models/recurring_todo_test.rb
+++ b/test/models/recurring_todo_test.rb
@@ -11,7 +11,7 @@ class RecurringTodoTest < ActiveSupport::TestCase
     @every_month = @monthly_every_last_friday
     @yearly = recurring_todos(:birthday_reinier)
 
-    @today = Time.now.utc
+    @today = Time.zone.now
     @tomorrow = @today + 1.day
     @in_three_days = @today + 3.days
     @in_four_days = @in_three_days + 1.day    # need a day after start_from
@@ -63,19 +63,19 @@ class RecurringTodoTest < ActiveSupport::TestCase
     #
     # start_from is way_back
     due_date1 = @yearly.get_due_date(nil)
-    due_date2 = @yearly.get_due_date(Time.now.utc + 1.day)
+    due_date2 = @yearly.get_due_date(Time.zone.now + 1.day)
     assert_equal due_date1, due_date2
 
     # start_from is in the future
-    @yearly.start_from = Time.now.utc + 1.week
+    @yearly.start_from = Time.zone.now + 1.week
     due_date1 = @yearly.get_due_date(nil)
-    due_date2 = @yearly.get_due_date(Time.now.utc + 1.day)
+    due_date2 = @yearly.get_due_date(Time.zone.now + 1.day)
     assert_equal due_date1, due_date2
 
     # start_from is nil
     @yearly.start_from = nil
     due_date1 = @yearly.get_due_date(nil)
-    due_date2 = @yearly.get_due_date(Time.now.utc + 1.day)
+    due_date2 = @yearly.get_due_date(Time.zone.now + 1.day)
     assert_equal due_date1, due_date2
   end
 
@@ -117,7 +117,7 @@ class RecurringTodoTest < ActiveSupport::TestCase
     assert_equal Time.zone.local(2021,6,8), @yearly.get_due_date(Time.zone.local(2019,6,1)) # also next year
     assert_equal Time.zone.local(2021,6,8), @yearly.get_due_date(Time.zone.local(2020,6,15)) # also next year
 
-    this_year = Time.now.utc.year
+    this_year = Time.zone.now.utc.year
     @yearly.start_from = Time.zone.local(this_year+1,6,12)
     due_date = @yearly.get_due_date(nil)
     assert_equal due_date.year, this_year+2

--- a/test/models/recurring_todos/abstract_recurrence_pattern_test.rb
+++ b/test/models/recurring_todos/abstract_recurrence_pattern_test.rb
@@ -8,7 +8,7 @@ module RecurringTodos
     def setup
       super
       @admin = users(:admin_user)
-    end 
+    end
 
     def test_pattern_builds_from_existing_recurring_todo
       rt = @admin.recurring_todos.first
@@ -121,9 +121,9 @@ module RecurringTodos
     def test_determine_start
       travel_to Time.zone.local(2013,1,1) do
         rt = create_recurring_todo
-        assert_equal "2013-01-01 00:00:00", rt.send(:determine_start, nil).to_s(:db), "no previous date, use today"
-        assert_equal "2013-01-01 00:00:00", rt.send(:determine_start, nil, 1.day).to_s(:db), "no previous date, use today without offset"
-        assert_equal "2013-01-02 00:00:00", rt.send(:determine_start, Time.zone.now, 1.day).to_s(:db), "use previous date and offset"
+        assert_equal Time.zone.parse("2013-01-01 00:00:00"), rt.send(:determine_start, nil), "no previous date, use today"
+        assert_equal Time.zone.parse("2013-01-01 00:00:00"), rt.send(:determine_start, nil, 1.day).to_s(:db), "no previous date, use today without offset"
+        assert_equal Time.zone.parse("2013-01-02 00:00:00"), rt.send(:determine_start, Time.zone.now, 1.day).to_s(:db), "use previous date and offset"
       end
     end
 
@@ -131,14 +131,14 @@ module RecurringTodos
       rt = create_recurring_todo
 
       # march 2014 has 5 saturdays, the last will return the 5th
-      assert_equal "2014-03-01 00:00:00", rt.send(:get_xth_day_of_month, 1, 6, 3, 2014).to_s(:db)
-      assert_equal "2014-03-22 00:00:00", rt.send(:get_xth_day_of_month, 4, 6, 3, 2014).to_s(:db)
-      assert_equal "2014-03-29 00:00:00", rt.send(:get_xth_day_of_month, 5, 6, 3, 2014).to_s(:db)
+      assert_equal Time.zone.parse("2014-03-01 00:00:00"), rt.send(:get_xth_day_of_month, 1, 6, 3, 2014).to_s(:db)
+      assert_equal Time.zone.parse("2014-03-22 00:00:00"), rt.send(:get_xth_day_of_month, 4, 6, 3, 2014).to_s(:db)
+      assert_equal Time.zone.parse("2014-03-29 00:00:00"), rt.send(:get_xth_day_of_month, 5, 6, 3, 2014).to_s(:db)
 
       # march 2014 has 4 fridays, the last will return the 4th
-      assert_equal "2014-03-07 00:00:00", rt.send(:get_xth_day_of_month, 1, 5, 3, 2014).to_s(:db)
-      assert_equal "2014-03-28 00:00:00", rt.send(:get_xth_day_of_month, 4, 5, 3, 2014).to_s(:db)
-      assert_equal "2014-03-28 00:00:00", rt.send(:get_xth_day_of_month, 5, 5, 3, 2014).to_s(:db)
+      assert_equal Time.zone.parse("2014-03-07 00:00:00"), rt.send(:get_xth_day_of_month, 1, 5, 3, 2014).to_s(:db)
+      assert_equal Time.zone.parse("2014-03-28 00:00:00"), rt.send(:get_xth_day_of_month, 4, 5, 3, 2014).to_s(:db)
+      assert_equal Time.zone.parse("2014-03-28 00:00:00"), rt.send(:get_xth_day_of_month, 5, 5, 3, 2014).to_s(:db)
 
       assert_raise(RuntimeError, "should check on valid weekdays"){ rt.send(:get_xth_day_of_month, 5, 9, 3, 2014) }
       assert_raise(RuntimeError, "should check on valid count x"){ rt.send(:get_xth_day_of_month, 6, 5, 3, 2014) }

--- a/test/models/todo_create_params_helper_test.rb
+++ b/test/models/todo_create_params_helper_test.rb
@@ -16,14 +16,14 @@ class TodoCreateParamsHelperTest < ActiveSupport::TestCase
   end
 
   def test_show_from_accessor
-    expected_date = Time.now
+    expected_date = Time.zone.now
     params =  ActionController::Parameters.new({ 'todo' => { 'show_from' => expected_date}})
     params_helper = Todos::TodoCreateParamsHelper.new(params, users(:admin_user))
     assert_equal(expected_date, params_helper.show_from)
   end
 
   def test_due_accessor
-    expected_date = Time.now
+    expected_date = Time.zone.now
     params =  ActionController::Parameters.new({ 'todo' => { 'due' => expected_date}})
     params_helper = Todos::TodoCreateParamsHelper.new(params, users(:admin_user))
     assert_equal(expected_date, params_helper.due)
@@ -119,5 +119,4 @@ class TodoCreateParamsHelperTest < ActiveSupport::TestCase
     params_helper = Todos::TodoCreateParamsHelper.new(params, users(:admin_user))
     assert_equal false, params_helper.context_specified_by_name?
   end
-
 end

--- a/test/models/todo_test.rb
+++ b/test/models/todo_test.rb
@@ -22,8 +22,8 @@ class TodoTest < ActiveSupport::TestCase
     assert_equal "Call Bill Gates to find out how much he makes per day", @not_completed1.description
     assert_nil @not_completed1.notes
     assert @not_completed1.completed? == false
-    assert_equal 1.week.ago.beginning_of_day.strftime("%Y-%m-%d %H:%M"), @not_completed1.created_at.beginning_of_day.strftime("%Y-%m-%d %H:%M")
-    assert_equal 2.week.from_now.beginning_of_day.strftime("%Y-%m-%d"), @not_completed1.due.strftime("%Y-%m-%d")
+    assert_equal 1.week.ago.utc.beginning_of_day, @not_completed1.created_at.utc
+    assert_equal 2.week.from_now.utc.beginning_of_day, @not_completed1.due.utc
     assert_nil @not_completed1.completed_at
     assert_equal 1, @not_completed1.user_id
   end
@@ -72,26 +72,26 @@ class TodoTest < ActiveSupport::TestCase
   def test_validate_show_from_must_be_a_date_in_the_future
     t = @not_completed2
     t.show_from = 1.week.ago
-    
+
     assert !t.save, "todo should not be saved without validation errors"
     assert_equal 1, t.errors.count
     assert_equal "must be a date in the future", t.errors[:show_from][0]
   end
-  
+
   def test_validate_circular_dependencies
     @completed.activate!
     @not_completed3=@completed
-    
+
     # 2 -> 1
     @not_completed1.add_predecessor(@not_completed2)
     assert @not_completed1.save!
     assert_equal 1, @not_completed2.successors.count
-    
+
     # 3 -> 2 -> 1
     @not_completed2.add_predecessor(@not_completed3)
     assert @not_completed2.save!
     assert_equal 1, @not_completed3.successors.count
-    
+
     # 1 -> 3 -> 2 -> 1 == circle
     assert_raises ActiveRecord::RecordInvalid do
       @not_completed3.add_predecessor(@not_completed1)
@@ -131,7 +131,7 @@ class TodoTest < ActiveSupport::TestCase
     t.toggle_completion!
     assert_equal :active, t.aasm.current_state
   end
-  
+
   def test_toggle_completion_with_show_from_in_future
     t = @not_completed1
     t.show_from= 1.week.from_now
@@ -140,12 +140,12 @@ class TodoTest < ActiveSupport::TestCase
     t.toggle_completion!
     assert_equal :completed, t.aasm.current_state
   end
-  
+
   def test_toggle_completion_with_show_from_in_past
     t = @not_completed1
     t.update_attribute(:show_from, 1.week.ago)
     assert_equal :active, t.aasm.current_state
-    
+
     assert t.toggle_completion!, "shoud be able to mark active todo complete even if show_from is set in the past"
     assert_equal :completed, t.aasm.current_state
   end
@@ -219,7 +219,7 @@ class TodoTest < ActiveSupport::TestCase
     # And I update the state of the todo from its project
     new_todo.update_state_from_project
     # Then the todo should be hidden
-    assert new_todo.hidden?    
+    assert new_todo.hidden?
   end
 
   def test_initial_state_defaults_to_active
@@ -280,7 +280,7 @@ class TodoTest < ActiveSupport::TestCase
     assert todo.pending?, "todo with predecessor should be blocked"
 
     # cannot activate if part of hidden project
-    assert_raise(AASM::InvalidTransition) { todo.activate! } 
+    assert_raise(AASM::InvalidTransition) { todo.activate! }
 
     todo.remove_predecessor(todo2)
     assert todo.reload.hidden?, "todo should be put back in hidden state"
@@ -337,7 +337,7 @@ class TodoTest < ActiveSupport::TestCase
     @not_completed1.add_predecessor(@not_completed2)
     @not_completed1.save_predecessors
     # blocking is not done automagically
-    @not_completed1.block! 
+    @not_completed1.block!
 
     assert @not_completed1.uncompleted_predecessors?
     assert @not_completed1.pending?, "a todo with predecessors should be pending"
@@ -358,7 +358,7 @@ class TodoTest < ActiveSupport::TestCase
     @not_completed1.add_predecessor_list("#{@not_completed2.id}, #{@not_completed3.id}")
     @not_completed1.save_predecessors
     # blocking is not done automagically
-    @not_completed1.block! 
+    @not_completed1.block!
 
     # Then @completed1 should have predecessors and should be blocked
     assert @not_completed1.uncompleted_predecessors?
@@ -526,18 +526,18 @@ class TodoTest < ActiveSupport::TestCase
     assert !older_created_todos.include?(todo_now)
     assert !recent_created_todos.include?(todo_old)
   end
-  
+
   def test_notes_are_rendered_on_save
     user = @completed.user
     todo = user.todos.create(:description => "test", :context => @completed.context)
-    
+
     assert_nil todo.notes
     assert_nil todo.rendered_notes
-    
+
     todo.notes = "*test*"
     todo.save!
     todo.reload
-    
+
     assert_equal "*test*", todo.notes
     assert_equal "<p><strong>test</strong></p>", todo.rendered_notes
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -75,7 +75,7 @@ class UserTest < ActiveSupport::TestCase
       assert_equal "is too long (maximum is 80 characters)", u.errors[:login][0]
     end
   end
-  
+
   def test_validate_correct_length_login
     assert_difference 'User.count' do
       create_user :login => generate_random_string(6)
@@ -206,14 +206,14 @@ class UserTest < ActiveSupport::TestCase
 
   def test_find_and_activate_deferred_todos_that_are_ready
     assert_equal 1, @admin_user.deferred_todos.count
-    @admin_user.deferred_todos[0].show_from = Time.now.utc - 5.seconds
+    @admin_user.deferred_todos[0].show_from = Time.zone.now - 5.seconds
     @admin_user.deferred_todos[0].save(:validate => false)
     @admin_user.deferred_todos.reload
     @admin_user.deferred_todos.find_and_activate_ready
     @admin_user.deferred_todos.reload
     assert_equal 0, @admin_user.deferred_todos.count
   end
-  
+
   def test_sort_active_projects_alphabetically
     u = users(:admin_user)
     u.projects.alphabetize(:state => "active")
@@ -221,7 +221,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 2, projects(:gardenclean).position
     assert_equal 3, projects(:moremoney).position
   end
-  
+
   def test_sort_active_projects_alphabetically_case_insensitive
     u = users(:admin_user)
     projects(:timemachine).name = projects(:timemachine).name.downcase
@@ -264,22 +264,22 @@ class UserTest < ActiveSupport::TestCase
     users(:other_user).update_attributes(:password => 'new password', :password_confirmation => 'new password')
     assert_equal users(:other_user), User.authenticate('jane', 'new password')
   end
-  
+
   def test_should_not_rehash_password
     users(:other_user).update_attributes(:login => 'jane2')
     assert_equal users(:other_user), User.authenticate('jane2', 'sesame')
   end
-  
+
   def test_should_authenticate_user
     assert_equal users(:other_user), User.authenticate('jane', 'sesame')
   end
-  
+
   def test_should_set_remember_token
     users(:other_user).remember_me
     assert_not_nil users(:other_user).remember_token
     assert_not_nil users(:other_user).remember_token_expires_at
   end
-  
+
   def test_should_unset_remember_token
     users(:other_user).remember_me
     assert_not_nil users(:other_user).remember_token
@@ -319,7 +319,7 @@ class UserTest < ActiveSupport::TestCase
 
     u.projects.actionize
 
-    assert_equal "3,2,1", u.projects.reload.map(&:id).join(",")    
+    assert_equal "3,2,1", u.projects.reload.map(&:id).join(",")
   end
 
   def test_remember_token
@@ -389,12 +389,12 @@ class UserTest < ActiveSupport::TestCase
     assert_equal expect_notes_count, Note.count, "expected #{nr_of_notes} notes to be gone"
     assert_equal expect_deps_count, Dependency.count, "expected #{nr_of_deps} dependencies to be gone"
   end
-    
+
   protected
 
   def create_user(options = {})
     options[:password_confirmation] = options[:password] unless options.has_key?(:password_confirmation) || !options.has_key?(:password)
     User.create({ :login => 'quire', :password => 'quire', :password_confirmation => 'quire' }.merge(options))
   end
-        
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,12 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 # set config for tests. Overwrite those read from config/site.yml. Use inject to avoid warning about changing CONSTANT
-{ "authentication_schemes" => ["database"], "prefered_auth" => "database", "email_dispatch" => nil}.inject( SITE_CONFIG ) { |h, elem| h[elem[0]] = elem[1]; h }
+{
+  "authentication_schemes" => ["database"],
+  "prefered_auth" => "database",
+  "email_dispatch" => nil,
+  "time_zone" => "Amsterdam"  # force UTC+1 so Travis triggers time zone failures
+}.inject( SITE_CONFIG ) { |h, elem| h[elem[0]] = elem[1]; h }
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
@@ -47,11 +52,11 @@ class ActiveSupport::TestCase
     end
     return string
   end
-  
+
   def assert_equal_dmy(date1, date2)
     assert_equal date1.strftime("%d-%m-%y"), date2.strftime("%d-%m-%y")
   end
-    
+
   def xml_document
     @xml_document ||= HTML::Document.new(@response.body, false, true)
   end
@@ -63,43 +68,43 @@ class ActiveSupport::TestCase
 end
 
 class ActionController::TestCase
-  
+
   def login_as(user)
     @request.session['user_id'] = user ? users(user).id : nil
   end
-  
+
   def assert_ajax_create_increments_count(name)
     assert_count_after_ajax_create(name, get_class_count + 1)
   end
-  
+
   def assert_ajax_create_does_not_increment_count(name)
     assert_count_after_ajax_create(name, get_class_count)
   end
-  
+
   def assert_count_after_ajax_create(name, expected_count)
     ajax_create(name)
     assert_equal(expected_count, get_class_count)
   end
-  
+
   def ajax_create(name)
     xhr :post, :create, get_model_class.downcase => {:name => name}
   end
-  
+
   def assert_xml_select(*args, &block)
     @html_document = xml_document
     assert_select(*args, &block)
   end
-  
+
   private
-  
+
   def get_model_class
     @controller.class.to_s.tableize.split("_")[0].camelcase.singularize  #don't ask... converts ContextsController to Context
   end
-  
+
   def get_class_count
     eval("#{get_model_class}.count")
   end
-  
+
 end
 
 class ActionDispatch::IntegrationTest
@@ -137,7 +142,7 @@ class ActionDispatch::IntegrationTest
   def assert_401_unauthorized_admin
     assert_response_and_body 401, "401 Unauthorized: Only admin users are allowed access to this function."
   end
-  
+
   def assert_responses_with_error(error_msg)
     assert_response 409
     assert_xml_select 'errors' do


### PR DESCRIPTION
There were several problems:
* Time.now returns the systems time, not the users time
* fixtures do not translate dates from timezone to utc, but stores the
  date verbatim
* calling a controller will set the timezone to the preference of the
  current_user. So it could be changed while you do not realize this. I
  fixed the failing test, but problems could be elsewhere