### PR TITLE
Completed todos are now selectable.

### DIFF
--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -269,11 +269,9 @@ module TodosHelper
   end
 
   def grip_span(todo=@todo)
-    unless todo.completed?
-      image_tag('grip.png', :width => '7', :height => '16', :border => '0',
-        :title => t('todos.drag_action_title'),
-        :class => 'grip')
-    end
+    image_tag('grip.png', :width => '7', :height => '16', :border => '0',
+      :title => t('todos.drag_action_title'),
+      :class => 'grip')
   end
 
   def tag_list_text(todo=@todo)


### PR DESCRIPTION
So far, the whole row with a todo was draggable, with handle grip_span.
This means for normal todos the whole action is draggable, but user
must drag it by clicking on grip_span.

Grip span has not been rendered for completed todos, so the whole row
could be dragged, preventing user from selecting any text in completed
todo.

This commit makes grip_span rendered also for completed tasks, allowing
them to be dragged by grip_span, but the rest of the text is selectable
like for normal todos.