### PR TITLE
Remove the Google Gadget Integration

### DIFF
--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,7 +1,7 @@
 class IntegrationsController < ApplicationController
   require 'mail'
 
-  skip_before_filter :login_required, :only => [:cloudmailin, :search_plugin, :google_gadget]
+  skip_before_filter :login_required, :only => [:cloudmailin, :search_plugin]
   skip_before_filter :verify_authenticity_token, only: [:cloudmailin]
 
   def index
@@ -15,10 +15,6 @@ class IntegrationsController < ApplicationController
   def search_plugin
     @icon_data = [File.open(File.join(Rails.root, 'app', 'assets', 'images', 'done.png')).read].
       pack('m').gsub(/\n/, '')
-  end
-
-  def google_gadget
-    render :layout => false, :content_type => Mime::XML
   end
 
   def cloudmailin

--- a/app/views/integrations/google_gadget.erb
+++ b/app/views/integrations/google_gadget.erb
@@ -1,5 +1,0 @@
-<Module>
-  <ModulePrefs title="Tracks" directory_title="Tracks" description="<%= t('integrations.gmail_description') %>" author="Tracks" author_email="butshesagirl@rousette.org.uk" author_affiliation="Tracks" author_location="UK" title_url="http://www.getontracks.org/" screenshot="http://www.getontracks.org/images/screens/tracks_home.png" thumbnail="http://www.getontracks.org/images/screens/tracks_home_thumb.png" category="communication" category2="tools" height="300">
-  </ModulePrefs>
-  <Content type="url" href="<%= root_url %>mobile"/>
-</Module>

--- a/app/views/integrations/index.de.html.erb
+++ b/app/views/integrations/index.de.html.erb
@@ -10,7 +10,6 @@
 <ul>
   <li><a href="#email-cron-section">Anstehende Aufgaben automatisch sich via E-Mail zusenden lassen</a></li>
   <li><a href="#message_gateway">Tracks mit einem Mail-Server integrieren, um Aufgaben via E-Mail zu erstellen</a></li>
-  <li><a href="#google_gadget">Tracks zu Ihrer Google Gmail Seite hinzuf&uuml;gen</a></li>
 </ul><br/>
 <p>Sie haben weitere Beispiele?
   <a href="http://www.getontracks.org/forums/viewforum/10/" title="Tracks | Tips and Tricks">Berichten Sie uns
@@ -50,18 +49,3 @@
   <p>You can also send all email to a specific Tracks user. Configure mail_dispatch in site.yml to <tt>single_user</tt> and pass the login of the user:
     <pre>TRACKS_MAIL_RECEIVER=<%=current_user.login%> /PATH/TO/TRACKS/bin/rails r -e production 'MessageGateway.receive(STDIN.read)'</pre>
 </p>
-
-<a name="google_gadget"> </a>
-<h2>Add Tracks as a Google Gmail gadget</h2>
-<p>
-  You can now manage your projects/actions inside Gmail using Tracks Gmail Gadget.
-  Add Tracks Gmail gadget to the sidebar of Gmail and track your next actions
-  or add new action without explicitly open new browser tab for Tracks. Steps to set it up:
-</p>
-<ul>
-  <li>Sign in to Gmail and click Settings in the top right of your Gmail page. In Gmail setting page, click Labs tab</li>
-  <li>Enable the "Add any gadget by URL" feature. You will find it at bottom of the list. Select Enable radio button and click Save Changes button.</li>
-  <li>Now you can see Gadgets tab added to Gmail Settings. Go to the Gadgets tab</li>
-  <li>Paste following link to the Add a gadget by its URL: and then click Add button:<br/>
-    <pre><%= integrations_url + "/google_gadget.xml" %></pre></li>
-</ul>

--- a/app/views/integrations/index.en.html.erb
+++ b/app/views/integrations/index.en.html.erb
@@ -12,7 +12,6 @@
   <li><a href="#message_gateway">Integrate Tracks with an email server to be able to send an action through email to Tracks</a></li>
   <li><a href="#mailgun">Send emails to Tracks with Mailgun</a>
   <li><a href="#todo_rich_message_format">Rich Todo Message email format</a>
-  <li><a href="#google_gadget">Add Tracks as a Google Gmail gadget</a></li>
 </ul><br/>
 <p>Do you have one of your own to add?
   <a href="http://www.getontracks.org/forums/viewforum/10/" title="Tracks | Tips and Tricks">Tell us about
@@ -118,18 +117,3 @@ Mailgun handling, as the data is processed the same way</p>
   </tr>
 </table>
 <p>All symbols are optional, and text up to the first symbol (or end of string) is used as the description of the todo</p>
-
-<a name="google_gadget"> </a>
-<h2>Add Tracks as a Google Gmail gadget</h2>
-<p>
-  You can now manage your projects/actions inside Gmail using Tracks Gmail Gadget.
-  Add Tracks Gmail gadget to the sidebar of Gmail and track your next actions
-  or add new action without explicitly open new browser tab for Tracks. Steps to set it up:
-</p>
-<ul>
-  <li>Sign in to Gmail and click Settings in the top right of your Gmail page. In Gmail setting page, click Labs tab</li>
-  <li>Enable the "Add any gadget by URL" feature. You will find it at bottom of the list. Select Enable radio button and click Save Changes button.</li>
-  <li>Now you can see Gadgets tab added to Gmail Settings. Go to the Gadgets tab</li>
-  <li>Paste following link to the Add a gadget by its URL: and then click Add button:<br/>
-    <pre><%= integrations_url + "/google_gadget" %></pre></li>
-</ul>

--- a/app/views/integrations/index.nl.html.erb
+++ b/app/views/integrations/index.nl.html.erb
@@ -10,7 +10,6 @@
 <ul>
   <li><a href="#email-cron-section">Email jezelf automatisch de acties met een aflopende deadline</a></li>
   <li><a href="#message_gateway">Integreer Tracks met een email server om een actie via email naar Tracks te sturen</a></li>
-  <li><a href="#google_gadget">Voeg tracks toe als een Google Gmail gadget</a></li>
 </ul><br/>
 <p>Heb je een tip om hier toe te voegen?
   <a href="http://www.getontracks.org/forums/viewforum/10/" title="Tracks | Tips and Tricks">Vertel ons er over in onze
@@ -51,19 +50,3 @@
   <p>Je kan ook alle email naar een specifieke Tracks gebruiker sturen. Stel mail_dispatch in site.yml in op <tt>single_user</tt> en geeft de login van de gebruiker door:
     <pre>TRACKS_MAIL_RECEIVER=<%=current_user.login%> /PATH/TO/TRACKS/bin/rails r -e production 'MessageGateway.receive(STDIN.read)'</pre>
 </p>
-
-<a name="google_gadget"> </a>
-<h2>Voeg tracks toe als een Google Gmail gadget</h2>
-<p>
-  Je kan nu ook jouw projects/actions beheren in Gmail met de Tracks Gmail Gadget.
-  Voeg Tracks Gmail gadget toe aan de sidebar van Gmail en volg jouw acties
-  of voeg een nieuwe actie toe zonder apart een nieuw browser tab/scherm te openen
-  voor Tracks. Om dit in te stellen:
-</p>
-<ul>
-  <li>Log bij Gmail in en kies Settings in de rechter-bovenkant van jouw Gmail pagina. In de Gmail setting pagina, kies de Labs tab</li>
-  <li>Zet de "Add any gadget by URL" feature aan. Deze kan je onderop de lijst vinden. Kies voor Enable and kies Save Changes.</li>
-  <li>Nu zie je dat de Gadgets tab is toegevoegd aan de Gmail Settings. Ga nu naar de Gadgets tab</li>
-  <li>Knip en plak de volgende link in de Add a gadget by its URL: en klik dan op de Add button:<br/>
-    <pre><%= integrations_url + "/google_gadget" %></pre></li>
-</ul>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -308,7 +308,6 @@ cs:
   footer:
     send_feedback: Poslat zpětnou vazbu na %{version}
   integrations:
-    gmail_description: Gadget pro Tracks do Gmailu
     opensearch_description: Prohledat Tracks
   layouts:
     mobile_navigation:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -313,7 +313,6 @@ de:
   footer:
     send_feedback: Senden Sie Feedback zu %{version}
   integrations:
-    gmail_description: Gadget, um Tracks als Gadget zu Googlemail hinzuzufügen
     opensearch_description: In Tracks suchen
   layouts:
     mobile_navigation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -797,7 +797,6 @@ en:
     save_status_message: "Note %{id} was saved"    
   integrations:
     opensearch_description: Search in Tracks
-    gmail_description: Gadget to add Tracks to Gmail as a gadget
   preferences:
     open_id_url: Your OpenID URL is
     staleness_starts_after: Staleness starts after %{days} days

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -310,7 +310,6 @@ es:
   footer:
     send_feedback: Envía comentarios sobre el %{version}
   integrations:
-    gmail_description: Gadget para añadir pistas a Gmail como un gadget
     opensearch_description: Buscar en las Tracks
   layouts:
     mobile_navigation:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -340,7 +340,6 @@ fr:
       submit: Sauvegarder %{model}
       update: Mettre à jour %{model}
   integrations:
-    gmail_description: Gadget pour ajouter Tracks à Gmail
     opensearch_description: Rechercher dans Tracks
   layouts:
     mobile_navigation:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -257,7 +257,6 @@ he:
   footer:
     send_feedback: "שליחת משוב על גירסא %{version}"
   integrations:
-    gmail_description: "חֲפִיץ להוספת מסלולים ל-Gmail"
     opensearch_description: "חיפוש במסלולים"
   layouts:
     mobile_navigation:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -358,7 +358,6 @@ nl:
       submit: Bewaar %{model}
       update: Bijwerken %{model}
   integrations:
-    gmail_description: Gadget om Tracks toe te voegen aan Gmail als een gadget
     opensearch_description: Zoek in Tracks
   layouts:
     mobile_navigation:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -376,7 +376,6 @@ ru:
       submit: "Сохранить %{model}"
       update: "Обновить %{model}"
   integrations:
-    gmail_description: "Гаджет для добавления Tracks в Gmail как гаджета боковой панели"
     opensearch_description: "Искать в Tracks"
   layouts:
     mobile_navigation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,6 @@ Rails.application.routes.draw do
   get 'integrations/rest_api' => "integrations#rest_api", :as => 'rest_api_docs'
   post 'integrations/cloudmailin' => 'integrations#cloudmailin'
   get 'integrations/search_plugin' => "integrations#search_plugin", :as => 'search_plugin'
-  get 'integrations/google_gadget.xml' => 'integrations#google_gadget', :as => 'google_gadget'
 
   get 'preferences' => "preferences#index"
   get 'preferences/render_date_format' => "preferences#render_date_format"


### PR DESCRIPTION
Google has discontinued the "Add any gadget by URL" Labs feature. Remove
the feature from the application.

Fixes #1843 