### PR TITLE
Simplify the return values when using basic auth

### DIFF
--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -195,15 +195,12 @@ module LoginSystem
     end
     if authdata and authdata[0] == 'Basic'
       data = Base64.decode64(authdata[1]).split(':')[0..1]
-      return {
+      {
         user: data[0],
         pass: data[1]
       }
     else
-      return {
-        user: ''.freeze,
-        pass: ''.freeze
-      }
+      {}
     end
   end
 


### PR DESCRIPTION
Returning a hash with explicit keys isn't strictly necessary with the
access methods we're using to get the values for those keys out of the
hash. Return an empty hash instead, simplifying the code.

Also remove the early return statements within the conditional. Those
are also unneeded since this is the last expression that's run in the
method.