### PR TITLE
Bump mysql2 to 0.3.20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'jquery-rails'
 # always possible on all platforms
 # Alternatively use --without <group> arguments to bundler to not install that group
 gem "sqlite3", group: :sqlite
-gem "mysql2", group: :mysql
+gem "mysql2", "~> 0.3.17", group: :mysql
 
 gem "RedCloth"
 gem "sanitize", ">=3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.11.1)
     multi_test (0.1.1)
-    mysql2 (0.3.16)
+    mysql2 (0.3.20)
     nokogiri (1.6.4)
       mini_portile (~> 0.6.0)
     nokogumbo (1.1.12)
@@ -245,7 +245,7 @@ DEPENDENCIES
   htmlentities
   jquery-rails
   mocha
-  mysql2
+  mysql2 (~> 0.3.17)
   paperclip
   rack-dev-mark
   rack-mini-profiler


### PR DESCRIPTION
I recently bumped my local MySQL install to 5.7, which didn't work with earlier versions of the gem. 

Keep it locked at the 0.3.x version due to problems with other apps and the 0.4.x versions.