### PR TITLE
Update the footer to be more responsive

### DIFF
--- a/app/assets/stylesheets/legacy.css.scss
+++ b/app/assets/stylesheets/legacy.css.scss
@@ -402,15 +402,6 @@ input.item-checkbox {
     border-top: 1px solid #999;
 }
 
-#footer {
-    clear: both;
-    font-size: 85%;
-    text-align: center;
-    color: #999;
-    margin: 20px 310px 5px 20px;
-    padding: 0px;
-}
-
 a.footer_link {
     color: #cc3334;
     font-style: normal;
@@ -435,10 +426,6 @@ a.footer_link {
 
     select#prefs_time_zone, select#prefs_sms_context_id {
         width: 250px;
-    }
-
-    div#footer {
-        margin-right:410px;
     }
 
     /* override jquery css to match tracks defaults better */

--- a/app/assets/stylesheets/login.css.scss
+++ b/app/assets/stylesheets/login.css.scss
@@ -44,8 +44,3 @@ body {
   @extend .form-group;
 }
 
-.footer {
-  @include make-xs-column(12);
-  @include make-sm-column(6);
-  @include make-sm-column-offset(3);
-}

--- a/app/assets/stylesheets/tracks.css.scss
+++ b/app/assets/stylesheets/tracks.css.scss
@@ -10,3 +10,23 @@
     border-radius: 2px;
   }
 }
+
+.footer {
+  @include make-xs-column(12);
+  @include make-sm-column(10);
+  @include make-sm-column-offset(1);
+  font-size: 85%;
+  text-align: center;
+  color: #999;
+  margin: 20px 0 5px;
+}
+
+.footer-line {
+  display: block;
+}
+
+@media screen and (min-width: 1170px) {
+  .footer-line {
+    display: inline;
+  }
+}

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,8 +1,13 @@
-<div id="footer">
-  <p><%= t('footer.send_feedback', :version => TRACKS_VERSION) %>: <a href="https://github.com/TracksApp/tracks/issues"><%= t('common.bugs')%></a> |
-    <a href="https://github.com/TracksApp/tracks/wiki"><%= t('common.wiki')%></a> |
-    <a href="http://groups.google.com/group/TracksApp"><%= t('common.mailing_list')%></a> |
-    <a href="http://www.getontracks.org/"><%= t('common.website')%></a> |
-    <a href="http://www.getontracks.org/development/"><%= t('common.contribute')%></a> |
-    <%= link_to(t('layouts.navigation.mobile'), todos_path(:format => 'm')) %></p>
+<div class="bootstrap">
+  <div class="footer">
+    <%= t('footer.send_feedback', :version => TRACKS_VERSION) %>
+    <span class="footer-line">
+      <a href="https://github.com/TracksApp/tracks/issues"><%= t('common.bugs')%></a> |
+      <a href="https://github.com/TracksApp/tracks/wiki"><%= t('common.wiki')%></a> |
+      <a href="http://groups.google.com/group/TracksApp"><%= t('common.mailing_list')%></a> |
+      <a href="http://www.getontracks.org/"><%= t('common.website')%></a> |
+      <a href="http://www.getontracks.org/development/"><%= t('common.contribute')%></a> |
+      <%= link_to(t('layouts.navigation.mobile'), todos_path(:format => 'm')) %>
+    </span>
+  </div>
 </div>


### PR DESCRIPTION
Matches the style of the existing footer and makes the links move to the next line instead of wrapping if the viewport is too small for all of the footer to fit on one line.

Also moves the footer over to bootstrap styles

This makes the footer work for both the login screen and other pages that aren't fully bootstrapped yet. It also solves a design issue that is really nitpicky but was driving me nuts. :smiley: