### PR TITLE
Sort current projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -58,7 +58,6 @@ class ProjectsController < ApplicationController
     @source_view = params['_source_view'] || 'review'
     @page_title = t('projects.list_reviews')
     @projects = current_user.projects.load
-    @contexts = current_user.contexts.load
     @projects_to_review = current_user.projects.select  {|p| p.needs_review?(current_user)}
     @stalled_projects = current_user.projects.select  {|p| p.stalled?}
     @blocked_projects = current_user.projects.select  {|p| p.blocked?}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -58,9 +58,9 @@ class ProjectsController < ApplicationController
     @source_view = params['_source_view'] || 'review'
     @page_title = t('projects.list_reviews')
     projects = current_user.projects
-    @projects_to_review = current_user.projects.select  {|p| p.needs_review?(current_user)}
-    @stalled_projects = current_user.projects.select  {|p| p.stalled?}
-    @blocked_projects = current_user.projects.select  {|p| p.blocked?}
+    @projects_to_review = projects.select  {|p| p.needs_review?(current_user)}
+    @stalled_projects = projects.select  {|p| p.stalled?}
+    @blocked_projects = projects.select  {|p| p.blocked?}
     @current_projects = current_user.projects.uncompleted.select  {|p| not(p.needs_review?(current_user))}
 
     init_not_done_counts(['project'])

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,7 +61,7 @@ class ProjectsController < ApplicationController
     @projects_to_review = projects.select  {|p| p.needs_review?(current_user)}
     @stalled_projects = projects.select  {|p| p.stalled?}
     @blocked_projects = projects.select  {|p| p.blocked?}
-    @current_projects = current_user.projects.uncompleted.select  {|p| not(p.needs_review?(current_user))}
+    @current_projects = projects.uncompleted.select { |p| not (p.needs_review?(current_user)) }.sort_by { |p| p.last_reviewed || Time.zone.at(0) }
 
     init_not_done_counts(['project'])
     init_project_hidden_todo_counts(['project'])

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -57,7 +57,7 @@ class ProjectsController < ApplicationController
   def review
     @source_view = params['_source_view'] || 'review'
     @page_title = t('projects.list_reviews')
-    @projects = current_user.projects.load
+    projects = current_user.projects.load
     @projects_to_review = current_user.projects.select  {|p| p.needs_review?(current_user)}
     @stalled_projects = current_user.projects.select  {|p| p.stalled?}
     @blocked_projects = current_user.projects.select  {|p| p.blocked?}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -57,7 +57,7 @@ class ProjectsController < ApplicationController
   def review
     @source_view = params['_source_view'] || 'review'
     @page_title = t('projects.list_reviews')
-    projects = current_user.projects.load
+    projects = current_user.projects
     @projects_to_review = current_user.projects.select  {|p| p.needs_review?(current_user)}
     @stalled_projects = current_user.projects.select  {|p| p.stalled?}
     @blocked_projects = current_user.projects.select  {|p| p.blocked?}

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -25,6 +25,16 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_equal 2, assigns['deferred_todos'].size
   end
 
+  def test_sorted_current_in_review
+    p = projects(:timemachine)
+    login_as :admin_user
+    get :review
+    current_projects = assigns['current_projects']
+    assert_equal 2, current_projects.length
+    assert_equal projects(:gardenclean), current_projects[0]
+    assert_equal projects(:moremoney), current_projects[1]
+  end
+
   def test_show_exposes_next_project_in_same_state
     login_as :admin_user
     get :show, :id => projects(:timemachine).to_param

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -6,6 +6,12 @@
 def today
   Time.zone.now.utc.beginning_of_day.to_s(:db)
 end
+def yesterday
+  1.day.ago.utc.beginning_of_day.to_s(:db)
+end
+def last_week
+  1.week.ago.utc.beginning_of_day.to_s(:db)
+end
 %>
 
 timemachine:
@@ -28,6 +34,7 @@ moremoney:
   user_id: 1
   created_at: <%= today %>
   updated_at: <%= today %>
+  last_reviewed: <%= yesterday %>
 
 gardenclean:
   id: 3
@@ -38,6 +45,7 @@ gardenclean:
   user_id: 1
   created_at: <%= today %>
   updated_at: <%= today %>
+  last_reviewed: <%= last_week %>
 
 attendrailsconf:
   id: 4


### PR DESCRIPTION
I don't understand what the `.load` is supposed to do.

We could also discuss to also sort the `review`, `stalled` and `blocked` lists.

I'd prefer to not sort the `review` list, as
- all of the projects need to be reviewed now/soon-ish
- the user might have defined an order based in priority

This fixes #1960 