### PR TITLE
add target="_blank" for generated links

### DIFF
--- a/lib/tracks/utils.rb
+++ b/lib/tracks/utils.rb
@@ -25,14 +25,17 @@ module Tracks
     def self.render_text(text)
       rendered = auto_link_message(text)
       rendered = textile(rendered)
-      rendered = helpers.auto_link(rendered, :link => :urls)
+      rendered = helpers.auto_link(rendered, :link => :urls, :html => {:target => '_blank'})
 
-      # add onenote and message protocols
-      config = Sanitize::Config.merge(Sanitize::Config::RELAXED,
-        :protocols => { 'a' => {'href' => Sanitize::Config::RELAXED[:protocols]['a']['href'] + ['onenote', 'message']}}
-        )
+      relaxed_config = Sanitize::Config::RELAXED
+      config = relaxed_config
 
-      rendered = Sanitize.clean(rendered, config)
+      # add onenote and message protocols, allow a target
+      a_href_config = relaxed_config[:protocols]['a']['href'] + %w(onenote message)
+      a_attributes = relaxed_config[:attributes]['a'] + ['target']
+      config = Sanitize::Config.merge(config, :protocols => {'a' => {'href' => a_href_config}}, :attributes => {'a' => a_attributes})
+
+      rendered = Sanitize.fragment(rendered, config)
       return rendered.html_safe
     end
 

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -842,11 +842,22 @@ class TodosControllerTest < ActionController::TestCase
     # See http://blog.swivel.com/code/2009/06/rails-auto_link-and-certain-query-strings.html
     login_as(:admin_user)
     todo = users(:admin_user).todos.first
-    url = "http://example.com/foo?bar=/baz"
+    url = 'http://example.com/foo?bar=/baz'
     todo.notes = "foo #{url} bar"
     todo.save!
     get :index
-    assert_select("a[href=#{url}]")
+    assert_select "a[href=#{url}]"
+  end
+
+  def test_link_opened_in_new_window
+    # issue #1747
+    login_as(:admin_user)
+    todo = users(:admin_user).todos.first
+    url = 'http://example.com/'
+    todo.notes = "foo #{url} bar"
+    todo.save!
+    get :index
+    assert_select "a[target='_blank']"
   end
 
   def test_format_note_normal


### PR DESCRIPTION
This causes the links to be opened in a new window/tab.
Existing (rendered) notes are not affected by this.

Fixes #1747