### PR TITLE
Make glyphicons available for use in the UI

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -49,3 +49,12 @@ body {
   color: $text-color;
   background-color: $body-bg;
 }
+
+@font-face{
+  font-family:'Glyphicons Halflings';
+  src: image-url("bootstrap/glyphicons-halflings-regular.eot");
+  src: image-url("bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"),
+  image-url("bootstrap/glyphicons-halflings-regular.woff") format("woff"),
+  image-url("bootstrap/glyphicons-halflings-regular.ttf") format("truetype"),
+  image-url("bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg")
+}


### PR DESCRIPTION
Ideally, it would have been possible to wrap this in the bootstrap only section of the application stylesheet, but the icons won't work when glyphicons are limited to bootstrap only bits of UI, so import them globally.