### PR TITLE
Add pry for debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,10 @@ group :development do
   gem "activerecord-deprecated_finders"
 end
 
+group :development, :test do
+  gem 'pry'
+end
+
 group :test do
   gem "factory_girl_rails"
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     codeclimate-test-reporter (0.4.1)
       simplecov (>= 0.7.1, < 1.0.0)
+    coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -112,6 +113,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     metaclass (0.0.4)
+    method_source (0.8.2)
     mime-types (2.99)
     mimemagic (0.3.0)
     mini_portile2 (2.0.0)
@@ -131,6 +133,10 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.5)
     rack-dev-mark (0.7.3)
       rack (>= 1.1)
@@ -183,6 +189,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    slop (3.6.0)
     spring (1.1.3)
     spring-commands-cucumber (1.0.1)
       spring (>= 0.9.1)
@@ -250,6 +257,7 @@ DEPENDENCIES
   mocha
   mysql2 (~> 0.3.17)
   paperclip
+  pry
   rack-dev-mark
   rack-mini-profiler
   rails (~> 4.1.11)


### PR DESCRIPTION
I add this manually too often, so let's get it in the Gemfile.

Rails recommends `byebug` but it's Ruby-2.2-only and I still often find myself working on 1.9.3. We can switch when we go to Rails 5.