### PR TITLE
Add RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+Rails:
+  Enabled: true
+
+AllCops:
+  Exclude:
+    - bin/*
+
+Metrics/LineLength:
+  Max: 120
+
+Style/Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
   gem "rack-mini-profiler"
   gem "rack-dev-mark"
   gem "activerecord-deprecated_finders"
+  gem "rubocop", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
       rspec-expectations (>= 2.7.0)
+    ast (2.2.0)
     autoprefixer-rails (5.1.0)
       execjs
       json
@@ -131,6 +132,9 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
+    parser (2.3.0.2)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     rack (1.5.5)
     rack-dev-mark (0.7.3)
       rack (>= 1.1)
@@ -155,12 +159,19 @@ GEM
       activesupport (= 4.1.14.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.1.0)
     rake (10.5.0)
     ref (1.0.5)
     rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rubocop (0.36.0)
+      parser (>= 2.3.0.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+    ruby-progressbar (1.7.5)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
     sanitize (3.0.3)
@@ -255,6 +266,7 @@ DEPENDENCIES
   rails (~> 4.1.11)
   rails_autolink
   rspec-expectations
+  rubocop
   sanitize (>= 3.0.0)
   sass-rails (~> 4.0)
   selenium-webdriver (>= 2.50)


### PR DESCRIPTION
* Exclude bin/ because it's generated code
* Max line length of 120 characters
* Documentation not required
* Prefer double-quoted strings

No real enforcement or code modification at this time, but I'd like to get this in place as a helper for future work.