### PR TITLE
Don't include a protocol or domain for relative_to_root

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
       var defaultTags = <%= default_tags_for_autocomplete.html_safe rescue '{}' %>;
       var dateFormat = '<%= date_format_for_date_picker %>';
       var weekStart = '<%= current_user.prefs.week_starts %>';
-      function relative_to_root(path) { return '<%= root_url %>'+path; };
+      function relative_to_root(path) { return '/' + path; };
       <% if current_user.prefs.refresh != 0 -%>
         setup_auto_refresh(<%= current_user.prefs["refresh"].to_i*60000 %>);
       <% end -%>


### PR DESCRIPTION
Tracks uses this javascript method in the application layout called `relative_to_root` to get relative paths for a lot of Javascript functions. However, it includes the fully qualified protocol and domain for the tracks site in question. If you have Tracks proxied through SSL with nginx, then you get a non-secure URL which causes the Javascript to not work to fetch things like contexts or projects for autocomplete.

Instead of using the `root_url` helper that Rails provides that won't know about SSL, just use a normal forward slash instead, so that you still get a path that's relative to the root instead of a URL.