### PR TITLE
On Travis, restrict Cucumber tests to MySQL builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - "cp config/site.yml.tmpl config/site.yml"
 
-script: "bin/rake ci"
+script: "if [[ $DATABASE_URL == mysql* ]]; then bundle exec rake ci:full; else bundle exec rake ci:lite; fi"
 
 notifications:
   email: false

--- a/lib/tasks/continuous_integration.rake
+++ b/lib/tasks/continuous_integration.rake
@@ -1,15 +1,32 @@
-task :ci do |t|
-  ENV['RAILS_ENV']  ||= "test"
+namespace :ci do
+  desc 'Continuous integration tests, without features'
+  task :lite do
+    ENV['RAILS_ENV']  ||= "test"
 
-  # test coverage from codeclimate
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+    puts 'Running "lite" test suite'
 
-  # local test coverage
-  require 'simplecov'
-  SimpleCov.start 'rails'
+    [:environment, 'db:create', 'test:all'].each do |t|
+      Rake::Task[t].invoke
+    end
+  end
 
-  [:environment, 'db:create', 'test:all', 'cucumber'].each do |t|
-    Rake::Task[t].invoke
+  desc 'Continuous integration tests, including features'
+  task :full do |t|
+    puts 'Running full test suite'
+
+    # test coverage from codeclimate
+    require "codeclimate-test-reporter"
+    CodeClimate::TestReporter.start
+
+    # local test coverage
+    require 'simplecov'
+    SimpleCov.start 'rails'
+
+    ['ci:lite', 'cucumber'].each do |t|
+      Rake::Task[t].invoke
+    end
   end
 end
+
+desc 'Alias for ci:full'
+task :ci => 'ci:full'


### PR DESCRIPTION
This will speed up the overall CI execution time.

It's possible this will miss things, but if a database-specific bug is filed because it isn't captured in our unit tests, it's a bug in the tests.

Ideally this could be limited to model tests only, but things aren't that well separated.