### PR TITLE
Selenium: scroll elements to bottom instead of top

### DIFF
--- a/features/support/tracks_cucumber_settings.rb
+++ b/features/support/tracks_cucumber_settings.rb
@@ -17,8 +17,12 @@ end
 if Capybara.javascript_driver == :selenium
   profile = Selenium::WebDriver::Firefox::Profile.new
   profile['intl.accept_languages'] = 'en'
+
+  capabilities = Selenium::WebDriver::Remote::Capabilities.firefox
+  capabilities['elementScrollBehavior'] = 1
+
   Capybara.register_driver :selenium_english do |app|
-    Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => profile)
+    Capybara::Selenium::Driver.new(app, browser: :firefox, profile: profile, desired_capabilities: capabilities)
   end
   Capybara.javascript_driver = :selenium_english
 end


### PR DESCRIPTION
This prevents UI elements from being hidden by the top navbar. See https://github.com/SeleniumHQ/selenium/issues/1202.

Not a fix to #1979, but heading in the right direction.

Before: 233 failures
After: 181 failures