### PR TITLE
Avoid using %i, which requires Ruby 2.0

### DIFF
--- a/app/views/preferences/_date_and_time.html.erb
+++ b/app/views/preferences/_date_and_time.html.erb
@@ -4,7 +4,7 @@
 <br/>
 Or pick one of the following:<br/>
 <div class="form-group btn-group" role="group" data-toggle="buttons">
-  <% %i{default short long longer}.each do |format| %>
+  <% [:default, :short, :long, :longer].each do |format| %>
     <label class="btn btn-default">
       <%= radio_button_tag("date_picker1", t("date.formats.#{format}")) %>
       <%= l(Time.zone.today, format: format) %>
@@ -18,7 +18,7 @@ Or pick one of the following:<br/>
 <br/>
 Or pick one of the following:<br/>
 <div class="form-group btn-group" role="group" data-toggle="buttons">
-  <% %i{default short long longer}.each do |format| %>
+  <% [:default, :short, :long, :longer].each do |format| %>
     <label class="btn btn-default">
       <%= radio_button_tag("date_picker2", t("date.formats.#{format}")) %>
       <%= l(Time.zone.today, format: format) %>


### PR DESCRIPTION
Fixes #1997

This should turn the 1.9.3 "lite" (i.e. SQLite) build green.