### PR TITLE
Include datepicker i18n only as needed

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,13 +16,6 @@
 
 //= require jquery-ui/autocomplete
 //= require jquery-ui/datepicker
-//= require jquery-ui/datepicker-cs
-//= require jquery-ui/datepicker-de
-//= require jquery-ui/datepicker-es
-//= require jquery-ui/datepicker-fr
-//= require jquery-ui/datepicker-he
-//= require jquery-ui/datepicker-nl
-//= require jquery-ui/datepicker-ru
 //= require jquery-ui/dialog
 //= require jquery-ui/droppable
 //= require jquery-ui/effect-highlight

--- a/app/assets/javascripts/tracks_pages.js
+++ b/app/assets/javascripts/tracks_pages.js
@@ -111,7 +111,6 @@ var TracksPages = {
     TodoItems.setup_autocomplete_for_predecessor();
   },
   setup_datepicker: function() {
-    $.datepicker.setDefaults($.datepicker.regional[i18n_locale]);
     $('input.Date').datepicker({
         'dateFormat': dateFormat,
         'firstDay': weekStart,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -169,6 +169,14 @@ module ApplicationHelper
     return js.html_safe
   end
 
+  def javascript_tag_for_i18n_datepicker
+    locale = I18n.locale
+    # do not include en as locale since this the available by default
+    if locale && locale != :en
+      javascript_include_tag("jquery-ui/datepicker-#{locale}")
+    end
+  end
+
   def done_path(controller_name, type)
     case controller_name
     when "contexts"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
       setup_periodic_check("<%=check_deferred_todos_path(:format => 'js')%>", 10*60, 'POST');
       <%= generate_i18n_strings %>
     </script>
+    <%= javascript_tag_for_i18n_datepicker %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'apple-touch-icon.png', :rel => 'apple-touch-icon', :type => 'image/png' %>
     <%= auto_discovery_link_tag(:rss, {:controller => "todos", :action => "index", :format => 'rss', :token => "#{current_user.token}"}, {:title => t('layouts.next_actions_rss_feed')}) %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,7 +5,7 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( print.css mobile.css )
+Rails.application.config.assets.precompile += %w( print.css mobile.css jquery-ui/datepicker-*.js )
 
 # add /app/assets/swfs to asset pipeline for charts
 Rails.application.config.assets.paths << Rails.root.join("app", "assets", "swfs")


### PR DESCRIPTION
* Restore the `javascript_tag_for_i18n_datepicker` helper (and actually use it)
* Include the datepicker i18n JS in the asset precompilation list

Ref #1975