### PR TITLE
Fix spacing in search results heading

### DIFF
--- a/app/views/search/_show_results_collection.html.erb
+++ b/app/views/search/_show_results_collection.html.erb
@@ -5,7 +5,11 @@ collection_title ||= 'unknown object'
 unless collection.empty?
 -%>
   <div id="<%=collection_name%>-container" class="container">
-    <h2><span id="<%=collection_name%>" class="badge"><%= collection.size %></span><%= collection_title %></h2>
+    <h2>
+      <span id="<%=collection_name%>" class="badge"><%= collection.size %></span>
+
+      <%= collection_title %>
+    </h2>
     <%= yield %>
   </div>
 <% end -%>


### PR DESCRIPTION
Based on the style used in the projects index page.

Fixes #2003.