### PR TITLE
Convert search page to bootstrap

### DIFF
--- a/app/assets/javascripts/tracks.js.erb
+++ b/app/assets/javascripts/tracks.js.erb
@@ -894,12 +894,6 @@ var RecurringTodosPage = {
     }
 };
 
-var SearchPage = {
-    setup_behavior: function() {
-        $('#search-form #search').focus();
-    }
-};
-
 /**************************************/
 /* generic Tracks functions           */
 /**************************************/
@@ -1145,7 +1139,7 @@ $(document).ready(function() {
     /* enable page specific behavior */
     $([ 'PreferencesPage', 'NotesPage', 'ProjectListPage', 'ContextListPage',
         'FeedsPage', 'RecurringTodosPage', 'TodoItems', 'TracksPages',
-        'TracksForm', 'SearchPage', 'UsersPage' ]).each(function() {
+        'TracksForm', 'UsersPage' ]).each(function() {
         eval(this+'.setup_behavior();');
     });
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,6 +1,15 @@
-<div id="display_box_search">
-  <%= form_tag(search_results_path, :id => 'search-form') do %>
-    <%= text_field_tag(:search, params[:search]) %>
-    <%= submit_tag t('common.search') %>
-  <% end %>
+<div class="bootstrap">
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-6 col-sm-offset-3">
+      <%= form_tag(search_results_path) do %>
+        <div class="form-group">
+          <%= label_tag 'Search', nil, class: 'sr-only' %>
+          <%= text_field_tag(:search, params[:search], class: 'form-control', autofocus: true) %>
+        </div>
+        <%= submit_tag t('common.search'), class: 'btn btn-primary pull-right' %>
+      <% end %>
+    </div>
+  </div>
+</div>
 </div>


### PR DESCRIPTION
How is this?

I removed the JS to focus the cursor in favour of HTML5 autofocus. Should I add a fallback for when it is not supported? 

Browser support info: http://caniuse.com/#feat=autofocus