### PR TITLE
Add a fallback to :other for i18n

### DIFF
--- a/config/initializers/i18n-config.rb
+++ b/config/initializers/i18n-config.rb
@@ -27,6 +27,7 @@ module I18n::Backend::Pluralization
                 n==1 ? :one : :other # default :en
             end
     end
+    key = :other if key == :few && !entry.has_key?(key) #fallback to :other if :few is missing
     raise InvalidPluralizationData.new(entry, n) unless entry.has_key?(key)
     entry[key]
   end


### PR DESCRIPTION
In most cases, translations don't supply `:few` even though the language
may support the construct. Instead of the app blowing up if the
translation for `:few` doesn't exist, fall back to `:other` instead.