### PR TITLE
Hold rubocop back to fix tests on 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ end
 
 group :development, :test do
   gem 'pry'
-  gem "rubocop", require: false
+  gem "rubocop", "~> 0.41.2", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
-    parser (2.3.1.2)
+    parser (2.3.1.4)
       ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.1)
@@ -202,7 +202,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    rubocop (0.42.0)
+    rubocop (0.41.2)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -265,7 +265,7 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    unicode-display_width (1.1.0)
+    unicode-display_width (1.1.1)
     uniform_notifier (1.6.2)
     websocket (1.2.2)
     will_paginate (3.0.7)
@@ -306,7 +306,7 @@ DEPENDENCIES
   rails-dom-testing!
   rails_autolink
   rspec-expectations
-  rubocop
+  rubocop (~> 0.41.2)
   sanitize (>= 3.0.0)
   sass-rails (~> 5.0)
   selenium-webdriver (>= 2.50)
@@ -323,4 +323,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
We'll git rid of 1.9.3 support with Rails 5 (#2031) but until that happens I'd like the tests to stay green.