### PR TITLE
show correct number in badge

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -951,7 +951,8 @@ end
       end
       from.project do
         unless @todo.project_id == nil
-          @down_count = current_user.projects.find(@todo.project_id).todos.active_or_hidden.count
+          project = current_user.projects.find(@todo.project_id)
+          @down_count = project.todos.active_or_hidden.count + project.todos.deferred.count + project.todos.pending.count
         end
       end
       from.deferred do


### PR DESCRIPTION
fixes #2058

Please advice on how to clean this up, and add proper tests!

The actual badge number (which is shown on page reload) is defined in `ProjectsController#show`. Similar code (duplicated?) is in `ContextController#show`.

When toggling an action as stated in #2058 the badge number is determined using `TodosController#determine_down_count`. Of the 30 lines or so, only a SINGLE result is tested.