### PR TITLE
Move alternative installation options to the wiki

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -4,15 +4,7 @@ The following instructions will guide you through the installation of Tracks fro
 
 This description is intended for people installing Tracks from scratch. If you would like to upgrade an existing installation, please see the [upgrade documentation](upgrading.md).
 
-Various Tracks users have contributed installation howtos for specific environments. They are [on the wiki](https://github.com/TracksApp/tracks/wiki/Installation-index).
-
-If you are not confident installing Tracks from source using these instructions, there are several alternative options provided by third parties:
-
-* If you’d like to install Tracks on a local machine, try the packaged version offered by [Bitnami](http://bitnami.org/stack/tracks) — it runs on Windows, Mac OS X and Linux.
-* If you’d like to run Tracks within a dedicated virtual machine, [JumpBox](http://jumpbox.com/app/tracks) provides preconfigured virtual machine images.
-* Several providers offer individual Tracks user accounts. A list of these providers can be found [on the wiki](https://github.com/TracksApp/tracks/wiki/Hosted-Tracks).
-
-(Please note that these third-party options may use older versions of Tracks.)
+For alternative installation options and tips for specific environments, please see [Installation](https://github.com/TracksApp/tracks/wiki/Installation) on the wiki.
 
 ## Prerequisites
 


### PR DESCRIPTION
I don't love having pointers to specific third parties in the actual Tracks source, so this change moves all that to the wiki.