### PR TITLE
Add Ruby 2.3 and 2.4 as CI build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
  - 2.0.0
  - 2.1
  - 2.2
+ - 2.3
+ - 2.4
 addons:
   firefox: 45.8.0esr
 env:


### PR DESCRIPTION
2.3 and 2.4 have been out for some time. We should probably make sure the project works with them. :smiley: