### PR TITLE
Fix the top 10 longest running projects list

### DIFF
--- a/app/models/stats/projects.rb
+++ b/app/models/stats/projects.rb
@@ -22,7 +22,7 @@ module Stats
 
     def find_top10_longest_running_projects
       projects = user.projects.order('created_at ASC')
-      projects.sort_by{ |p| p.running_time }.take(10)
+      projects.sort_by{ |p| p.running_time }.reverse.take(10)
     end
 
   end

--- a/test/controllers/stats_controller_test.rb
+++ b/test/controllers/stats_controller_test.rb
@@ -51,6 +51,9 @@ class StatsControllerTest < ActionController::TestCase
     assert_equal 4, totals.tags
     assert_equal 2, totals.unique_tags
 
+    longest_running_projects = assigns['stats'].projects.runtime
+    assert_equal longest_running_projects, users(:admin_user).projects.order('created_at').reverse
+
     Time.zone = users(:admin_user).prefs.time_zone # calculations are done in users timezone
     assert_equal 2.weeks.ago.at_midnight, totals.first_action_at.at_midnight
   end


### PR DESCRIPTION
Sorting by running time without a reverse takes the shortest running
projects.

Fixes #2085