### PR TITLE
Makes force_ssl configurable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = SITE_CONFIG['force_ssl']
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/site.yml.tmpl
+++ b/config/site.yml.tmpl
@@ -25,6 +25,9 @@ secure_cookies: false
 #
 secret_token: "change-me"
 
+# Set to true when your application is running with https
+force_ssl: false
+
 # Configure how static assets (images, stylesheets, etc.) will be served.
 # The best practice is to have a proxying web server such as Apache or Nginx
 # serve static assets (images, stylesheets, javascript) for you. Change

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -65,6 +65,7 @@ Tracks is built upon a number of Ruby libraries (known as ‘gems’). The Bundl
 3. Open the file `config/site.yml`, and read through the settings to make sure that they suit your setup. In most cases, all you need to change are the `secret_token`, the administrator email address (`admin_email`), and the time zone setting. For the time zone setting you can use the command `bundle exec rake time:zones:local` to see all available timezones on your machine
 4. If you are using Windows, you may need to check the ‘shebang’ lines (`#!/usr/bin/env ruby`) of the `/public/dispatch.*` files and all the files in the `/script` directory. They are set to `#!/usr/bin/env ruby` by default. This should work for all Unix based setups (Linux or Mac OS X), but Windows users will probably have to change it to something like `#c:/ruby/bin/ruby` to point to the Ruby binary on your system.
 5. If you intend to deploy Tracks using its included web server, you’ll need to uncomment and change the `serve_static_assets` configuration option to `true` in `config/site.yml` in order for the images, stylesheets, and javascript files to be served correctly.
+6. If you intend to use Tracks behind a web server or reverse proxy with https enabled, ensure to set `force_ssl` option to `true`.
 
 ## Populate your database with the Tracks schema
 


### PR DESCRIPTION
This is needed when tracks is running behind a webserver with https. 