### PR TITLE
Fix german locale mobile Header; refs #1745

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -320,7 +320,7 @@ de:
       feeds: Feeds
       home: Home
       logout: Abmelden
-      new_action: Neue Aufgabe
+      new_action: Neu
       projects: Projekte
       starred: Markiert
       tickler: Notizbuch


### PR DESCRIPTION
This fixes issue #1745 by shorten link text. The meaning of the text is still clear. 