### PR TITLE
Use `rake test` instead of `ci:lite`

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -28,5 +28,5 @@ script/poll-for-db
 # bin/rails db:environment:set RAILS_ENV=test || true
 
 bin/rake db:reset
-bin/rake ci:lite
+bin/rake test
 


### PR DESCRIPTION
The `ci:lite` task is busted but the `test` task works just fine. Discovered this while testing a rubocop upgrade and ran `rake test` before committing.