### PR TITLE
Remove some friction when running in development

### DIFF
--- a/script/console
+++ b/script/console
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+appdir=$(cd $(dirname "$0")/.. && pwd)
+[ -f /etc/app-env ] || exec "$appdir/script/docker-environment" $0 $@
+
+export RAILS_ENV='development'
+bin/rails console

--- a/script/docker-environment
+++ b/script/docker-environment
@@ -13,4 +13,5 @@ cmd="$@"; [ "$#" -eq 0 ] && cmd=bash
 export VOLUME="$appdir:/app"
 image=${DOCKER_IMAGE:=web}
 
-exec docker-compose run --rm $image $cmd
+port_publish=""; [ "${BIND_DOCKER_SERVICE_PORTS:-}" = 1 ] && port_publish="--service-ports"
+exec docker-compose run $port_publish --rm $image $cmd

--- a/script/server
+++ b/script/server
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+export BIND_DOCKER_SERVICE_PORTS=1
+appdir=$(cd $(dirname "$0")/.. && pwd)
+[ -f /etc/app-env ] || exec "$appdir/script/docker-environment" $0 $@
+
+bin/rails server -b 0.0.0.0


### PR DESCRIPTION
The docker based development environment is great for abstracting away all the various system details (and hopefully makes things easier to get going on Windows) but unless you know all the various switches to toggle to work with docker, it can be a pain in the neck.

This pull request adds a few extra scripts to bring up a rails console or a rails server. It also adds a bit of functionality that was missing before to get `docker-compose` to publish the service ports so you could actually get to the server that you're running :smile: