### PR TITLE
Compatibility updates for newer versions of Rails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,10 +119,10 @@ class ApplicationController < ActionController::Base
   # versions. Unfortunately, I ran into a lot of trouble simply registering a
   # new mime type 'text/html' with format :m because :html already is linked to
   # that mime type and the new registration was forcing all html requests to be
-  # rendered in the mobile view. The before_action and after_filter hackery
+  # rendered in the mobile view. The before_action and after_action hackery
   # below accomplishs that implementation goal by using a 'fake' mime type
   # during the processing and then setting it to 'text/html' in an
-  # 'after_filter' -LKM 2007-04-01
+  # 'after_action' -LKM 2007-04-01
   def mobile?
     return params[:format] == 'm'
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,13 +12,13 @@ class ApplicationController < ActionController::Base
   layout proc{ |controller| controller.mobile? ? "mobile" : "application" }
   # exempt_from_layout /\.js\.erb$/
 
-  before_filter :set_session_expiration
-  before_filter :set_time_zone
-  before_filter :set_zindex_counter
-  before_filter :set_locale
-  append_before_filter :set_group_view_by
-  prepend_before_filter :login_required
-  prepend_before_filter :enable_mobile_content_negotiation
+  before_action :set_session_expiration
+  before_action :set_time_zone
+  before_action :set_zindex_counter
+  before_action :set_locale
+  append_before_action :set_group_view_by
+  prepend_before_action :login_required
+  prepend_before_action :enable_mobile_content_negotiation
   
   def set_locale
     locale = params[:locale] # specifying a locale in the request takes precedence
@@ -119,7 +119,7 @@ class ApplicationController < ActionController::Base
   # versions. Unfortunately, I ran into a lot of trouble simply registering a
   # new mime type 'text/html' with format :m because :html already is linked to
   # that mime type and the new registration was forcing all html requests to be
-  # rendered in the mobile view. The before_filter and after_filter hackery
+  # rendered in the mobile view. The before_action and after_filter hackery
   # below accomplishs that implementation goal by using a 'fake' mime type
   # during the processing and then setting it to 'text/html' in an
   # 'after_filter' -LKM 2007-04-01

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_failure message, status = 404
-    render :text => message, :status => status
+    render :body => message, :status => status
   end
 
   # Returns a count of next actions in the given context or project The result
@@ -147,7 +147,7 @@ class ApplicationController < ActionController::Base
 
   def admin_login_required
     unless User.find(session['user_id']).is_admin
-      render :text => t('errors.user_unauthorized'), :status => 401
+      render :body => t('errors.user_unauthorized'), :status => 401
       return false
     end
   end

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -1,6 +1,6 @@
 class CalendarController < ApplicationController
-  skip_before_filter :login_required, :only => [:show]
-  prepend_before_filter :login_or_feed_token_required, :only => [:show]
+  skip_before_action :login_required, :only => [:show]
+  prepend_before_action :login_or_feed_token_required, :only => [:show]
 
   def show
     @source_view = 'calendar'

--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -61,7 +61,7 @@ class ContextsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :text => 'Context not found', :status => 404 }
+        format.html { render :body => 'Context not found', :status => 404 }
         format.xml  { render :xml => '<error>Context not found</error>', :status => 404 }
       end
     end
@@ -116,7 +116,7 @@ class ContextsController < ApplicationController
           if @saved
             render :xml => @context.to_xml( :except => :user_id )
           else
-            render :text => "Error on update: #{@context.errors.full_messages.inject("") {|v, e| v + e + " " }}", :status => 409
+            render :body => "Error on update: #{@context.errors.full_messages.inject("") {|v, e| v + e + " " }}", :status => 409
           end
         }
     end
@@ -142,7 +142,7 @@ class ContextsController < ApplicationController
         @down_count = current_user.contexts.size
         update_state_counts
       end
-      format.xml { render :text => "Deleted context #{@context.name}" }
+      format.xml { render :body => "Deleted context #{@context.name}" }
     end
   end
 
@@ -222,7 +222,7 @@ class ContextsController < ApplicationController
 
   def render_autocomplete
     lambda do
-      render :text => for_autocomplete(current_user.contexts, params[:term])
+      render :body => for_autocomplete(current_user.contexts, params[:term])
     end
   end
 

--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -151,7 +151,7 @@ class ContextsController < ApplicationController
   def order
     context_ids = params["container_context"]
     @projects = current_user.contexts.update_positions( context_ids )
-    render :nothing => true
+    head :ok
   rescue
     notify :error, $!
     redirect_to :action => 'index'

--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -2,10 +2,10 @@ class ContextsController < ApplicationController
 
   helper :todos
 
-  before_filter :init, :except => [:index, :create, :destroy, :order]
-  before_filter :set_context_from_params, :only => [:update, :destroy]
-  skip_before_filter :login_required, :only => [:index]
-  prepend_before_filter :login_or_feed_token_required, :only => [:index]
+  before_action :init, :except => [:index, :create, :destroy, :order]
+  before_action :set_context_from_params, :only => [:update, :destroy]
+  skip_before_action :login_required, :only => [:index]
+  prepend_before_action :login_or_feed_token_required, :only => [:index]
 
   def index
     @all_contexts    = current_user.contexts

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,8 +1,8 @@
 class IntegrationsController < ApplicationController
   require 'mail'
 
-  skip_before_filter :login_required, :only => [:cloudmailin, :search_plugin]
-  skip_before_filter :verify_authenticity_token, only: [:cloudmailin]
+  skip_before_action :login_required, :only => [:cloudmailin, :search_plugin]
+  skip_before_action :verify_authenticity_token, only: [:cloudmailin]
 
   def index
     @page_title = 'TRACKS::Integrations'

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -19,14 +19,14 @@ class IntegrationsController < ApplicationController
 
   def cloudmailin
     if !verify_cloudmailin_signature
-      render :text => "Message signature verification failed.", :status => 403
+      render :body => "Message signature verification failed.", :status => 403
       return false
     end
 
     if process_message(params[:message])
-      render :text => 'success', :status => 200
+      render :body => 'success', :status => 200
     else
-      render :text => "No user found or other error", :status => 404
+      render :body => "No user found or other error", :status => 404
     end
   end
 

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -1,10 +1,10 @@
 class LoginController < ApplicationController
 
   layout 'login'
-  skip_before_filter :set_session_expiration
-  skip_before_filter :login_required
-  before_filter :login_optional
-  before_filter :get_current_user
+  skip_before_action :set_session_expiration
+  skip_before_action :login_required
+  before_action :login_optional
+  before_action :get_current_user
 
   protect_from_forgery :except => [:check_expiry, :login]
 

--- a/app/controllers/mailgun_controller.rb
+++ b/app/controllers/mailgun_controller.rb
@@ -2,8 +2,8 @@ require 'openssl'
 
 class MailgunController < ApplicationController
 
-  skip_before_filter :login_required, :only => [:mailgun]
-  before_filter :verify, :only => [:mailgun]
+  skip_before_action :login_required, :only => [:mailgun]
+  before_action :verify, :only => [:mailgun]
   protect_from_forgery with: :null_session
 
   def mailgun

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -38,7 +38,7 @@ class NotesController < ApplicationController
         end
       end
       format.html do
-        render :text => 'unexpected request for html rendering'
+        render :body => 'unexpected request for html rendering'
       end
     end
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,6 @@
 class NotesController < ApplicationController
 
-  before_filter :set_source_view
+  before_action :set_source_view
 
   def index
     @all_notes = current_user.notes

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -28,7 +28,7 @@ class PreferencesController < ApplicationController
 
   def render_date_format
     format = params[:date_format]
-    render :text => l(Date.current, :format => format)
+    render :body => l(Date.current, :format => format)
   end
 
 private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -48,7 +48,7 @@ class ProjectsController < ApplicationController
         end
         format.autocomplete do
           projects = current_user.projects.active + current_user.projects.hidden
-          render :text => for_autocomplete(projects, params[:term])
+          render :body => for_autocomplete(projects, params[:term])
         end
       end
     end
@@ -237,7 +237,7 @@ class ProjectsController < ApplicationController
         @projects = current_user.projects
         template = 'projects/update_project_name'
       else
-        render :text => success_text || 'Success'
+        render :body => success_text || 'Success'
         return
       end
     else
@@ -252,7 +252,7 @@ class ProjectsController < ApplicationController
         if @saved
           render :xml => @project.to_xml( :except => :user_id )
         else
-          render :text => "Error on update: #{@project.errors.full_messages.inject("") {|v, e| v + e + " " }}", :status => 409
+          render :body => "Error on update: #{@project.errors.full_messages.inject("") {|v, e| v + e + " " }}", :status => 409
         end
       }
     end
@@ -274,7 +274,7 @@ class ProjectsController < ApplicationController
         @down_count = current_user.projects.size
         update_state_counts
       }
-      format.xml { render :text => "Deleted project #{@project.name}" }
+      format.xml { render :body => "Deleted project #{@project.name}" }
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,11 +1,11 @@
 class ProjectsController < ApplicationController
 
   helper :application, :todos, :notes
-  before_filter :set_source_view
-  before_filter :set_project_from_params, :only => [:update, :destroy, :show, :edit, :set_reviewed]
-  before_filter :default_context_filter, :only => [:create, :update]
-  skip_before_filter :login_required, :only => [:index]
-  prepend_before_filter :login_or_feed_token_required, :only => [:index]
+  before_action :set_source_view
+  before_action :set_project_from_params, :only => [:update, :destroy, :show, :edit, :set_reviewed]
+  before_action :default_context_filter, :only => [:create, :update]
+  skip_before_action :login_required, :only => [:index]
+  prepend_before_action :login_or_feed_token_required, :only => [:index]
 
   def index
     @source_view = params['_source_view'] || 'project_list'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -281,7 +281,7 @@ class ProjectsController < ApplicationController
   def order
     project_ids = params["container_project"]
     @projects = current_user.projects.update_positions( project_ids )
-    render :nothing => true
+    head :ok
   rescue
     notify :error, $!
     redirect_to :action => 'index'

--- a/app/controllers/recurring_todos_controller.rb
+++ b/app/controllers/recurring_todos_controller.rb
@@ -2,8 +2,8 @@ class RecurringTodosController < ApplicationController
 
   helper :todos, :recurring_todos
 
-  append_before_filter :init, :only => [:index, :new, :edit, :create]
-  append_before_filter :get_recurring_todo_from_param, :only => [:destroy, :toggle_check, :toggle_star, :edit, :update]
+  append_before_action :init, :only => [:index, :new, :edit, :create]
+  append_before_action :get_recurring_todo_from_param, :only => [:destroy, :toggle_check, :toggle_star, :edit, :update]
 
   def index
     @page_title = t('todos.recurring_actions_title')

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,7 +3,7 @@ class StatsController < ApplicationController
   SECONDS_PER_DAY = 86400;
 
   helper :todos, :projects, :recurring_todos
-  append_before_filter :init, :except => :index
+  append_before_action :init, :except => :index
 
   def index
     @page_title = t('stats.index_title')

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1030,12 +1030,12 @@ end
         context = current_user.contexts.find(todo.context_id)
         @remaining_deferred_or_pending_count = context.todos.deferred_or_blocked.count
 
-        remaining_actions_in_context = context.todos(true).active
+        remaining_actions_in_context = context.todos.reload.active
         remaining_actions_in_context = remaining_actions_in_context.not_hidden if !context.hidden?
         @remaining_in_context = remaining_actions_in_context.count
 
         if @todo_was_deferred_or_blocked
-          actions_in_target = current_user.contexts.find(@todo.context_id).todos(true).active
+          actions_in_target = current_user.contexts.find(@todo.context_id).todos.reload.active
           actions_in_target = actions_in_target.not_hidden if !context.hidden?
         else
           actions_in_target = @todo.context.todos.deferred_or_blocked
@@ -1212,7 +1212,7 @@ end
   def update_tags
     if params[:tag_list]
       @todo.tag_with(params[:tag_list])
-      @todo.tags(true) #force a reload for proper rendering
+      @todo.tags.reload #force a reload for proper rendering
     end
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,8 +1,8 @@
 class TodosController < ApplicationController
 
-  skip_before_filter :login_required, :only => [:index, :tag]
-  prepend_before_filter :login_or_feed_token_required, :only => [:index, :tag]
-  append_before_filter :find_and_activate_ready, :only => [:index, :list_deferred]
+  skip_before_action :login_required, :only => [:index, :tag]
+  prepend_before_action :login_or_feed_token_required, :only => [:index, :tag]
+  append_before_action :find_and_activate_ready, :only => [:index, :list_deferred]
 
   protect_from_forgery :except => :check_deferred
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -544,7 +544,7 @@ class TodosController < ApplicationController
         render
       end
 
-      format.xml { render :text => '200 OK. Action deleted.', :status => 200 }
+      format.xml { render :body => '200 OK. Action deleted.', :status => 200 }
 
     end
   end
@@ -710,7 +710,7 @@ class TodosController < ApplicationController
     tags_all = tags_all - tags_beginning
 
     respond_to do |format|
-      format.autocomplete { render :text => for_autocomplete(tags_beginning+tags_all, params[:term]) }
+      format.autocomplete { render :body => for_autocomplete(tags_beginning+tags_all, params[:term]) }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,8 @@
 class UsersController < ApplicationController
 
-  before_filter :admin_login_required, :only => [ :index, :show, :destroy ]
-  skip_before_filter :login_required, :only => [ :new, :create ]
-  prepend_before_filter :login_optional, :only => [ :new, :create ]
+  before_action :admin_login_required, :only => [ :index, :show, :destroy ]
+  skip_before_action :login_required, :only => [ :new, :create ]
+  prepend_before_action :login_optional, :only => [ :new, :create ]
 
   # GET /users GET /users.xml
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,7 +99,7 @@ class UsersController < ApplicationController
       end
       format.xml do
         unless current_user && current_user.is_admin
-          render :text => "401 Unauthorized: Only admin users are allowed access to this function.", :status => 401
+          render :body => "401 Unauthorized: Only admin users are allowed access to this function.", :status => 401
           return
         end
         unless check_create_user_params
@@ -110,7 +110,7 @@ class UsersController < ApplicationController
         user.password_confirmation = user_params[:password]
         saved = user.save
         unless user.new_record?
-          render :text => t('users.user_created'), :status => 200
+          render :body => t('users.user_created'), :status => 200
         else
           render_failure user.errors.to_xml, 409
         end

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -206,7 +206,7 @@ module LoginSystem
 
   def basic_auth_denied
       response.headers["WWW-Authenticate"] = "Basic realm=\"'Tracks Login Required'\""
-      render :text => t('login.unsuccessful'), :status => 401
+      render :body => t('login.unsuccessful'), :status => 401
   end
 
 private

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -55,7 +55,7 @@ module LoginSystem
     true
   end
 
-  # When called with before_filter :login_from_cookie will check for an :auth_token
+  # When called with before_action :login_from_cookie will check for an :auth_token
   # cookie and log the user back in if appropriate
   def login_from_cookie
     return unless cookies[:auth_token] && !logged_in?
@@ -82,7 +82,7 @@ module LoginSystem
 
   # login_required filter. add
   #
-  #   before_filter :login_required
+  #   before_action :login_required
   #
   # if the controller should be under any rights management.
   # for finer access control you can overwrite


### PR DESCRIPTION
I've been decomposing #2084 in order to make the actual Rails upgrade easier, since 5.1 and 5.2 will be after 5.0. This splits out the various updates to the Rails API that are available to us in Rails 4.2 into it's own PR.

To be clear, these are all @dnrce's changes, I'm just splitting up how they're applyed to the code base.