### PR TITLE
Remove all the deprecations seen in the tests

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -17,7 +17,7 @@ class CalendarController < ApplicationController
         cookies[:mobile_url]= {:value => request.fullpath, :secure => SITE_CONFIG['secure_cookies']}
       }
       format.ics   {
-        render :action => 'show', :layout => false, :content_type => Mime::ICS
+        render :action => 'show', :layout => false, :content_type => Mime[:ics]
       }
       format.xml {
         render :xml => @due_all.to_xml( *todo_xml_params )

--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -26,9 +26,9 @@ class ContextsController < ApplicationController
         @feed_description = "Lists all the contexts for #{current_user.display_name}"
       end
       format.text do
-        # somehow passing Mime::TEXT using content_type to render does not work
-        headers['Content-Type']=Mime::TEXT.to_s
-        render :action => 'index', :layout => false, :content_type => Mime::TEXT
+        # somehow passing Mime[:text] using content_type to render does not work
+        headers['Content-Type']=Mime[:text].to_s
+        render :action => 'index', :layout => false, :content_type => Mime[:text]
       end
       format.autocomplete &render_autocomplete
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -43,8 +43,8 @@ class ProjectsController < ApplicationController
           @feed_description = I18n.t('models.project.feed_description', :username => current_user.display_name)
         end
         format.text do
-          # somehow passing Mime::TEXT using content_type to render does not work
-          headers['Content-Type']=Mime::TEXT.to_s
+          # somehow passing Mime[:text] using content_type to render does not work
+          headers['Content-Type']=Mime[:text].to_s
         end
         format.autocomplete do
           projects = current_user.projects.active + current_user.projects.hidden
@@ -114,9 +114,9 @@ class ProjectsController < ApplicationController
     @projects = current_user.projects.active
     respond_to do |format|
       format.text  {
-        # somehow passing Mime::TEXT using content_type to render does not work
-        headers['Content-Type']=Mime::TEXT.to_s
-        render :action => 'index_text_projects_and_actions', :layout => false, :content_type => Mime::TEXT
+        # somehow passing Mime[:text] using content_type to render does not work
+        headers['Content-Type']=Mime[:text].to_s
+        render :action => 'index_text_projects_and_actions', :layout => false, :content_type => Mime[:text]
       }
     end
   end

--- a/app/controllers/todos/todo_create_params_helper.rb
+++ b/app/controllers/todos/todo_create_params_helper.rb
@@ -110,7 +110,7 @@ module Todos
     end
 
     def add_errors(model)
-      @errors.each {|e| model.errors[ e[:attribute] ] = e[:message] }
+      @errors.each {|e| model.errors.add(e[:attribute], e[:message]) }
     end
 
     private

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -43,9 +43,9 @@ class TodosController < ApplicationController
         render :action => 'index'.freeze
       end
       format.text  do
-        # somehow passing Mime::TEXT using content_type to render does not work
-        headers['Content-Type'.freeze]=Mime::TEXT.to_s
-        render :content_type => Mime::TEXT
+        # somehow passing Mime[:text] using content_type to render does not work
+        headers['Content-Type'.freeze]=Mime[:text].to_s
+        render :content_type => Mime[:text]
       end
       format.xml do
         @xml_todos = params[:limit_to_active_todos] ? @not_done_todos : @todos
@@ -670,7 +670,7 @@ class TodosController < ApplicationController
         cookies[:mobile_url]= {:value => request.fullpath, :secure => SITE_CONFIG['secure_cookies']}
       }
       format.text {
-        render :action => 'index', :layout => false, :content_type => Mime::TEXT
+        render :action => 'index', :layout => false, :content_type => Mime[:text]
       }
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,9 +28,6 @@ module Tracksapp
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
-
     # configure Tracks to handle deployment in a subdir
     config.relative_url_root = SITE_CONFIG['subdir'] if SITE_CONFIG['subdir']
   end

--- a/lib/tracks/attribute_handler.rb
+++ b/lib/tracks/attribute_handler.rb
@@ -108,7 +108,7 @@ module Tracks
 
     def normalize(attributes)
       # make sure the hash keys are all symbols
-      Hash[attributes.map{|k,v| [k.to_sym,v]}]
+      attributes.transform_keys(&:to_sym)
     end
 
     def safe_attributes

--- a/test/controllers/calendar_controller_test.rb
+++ b/test/controllers/calendar_controller_test.rb
@@ -18,13 +18,13 @@ class CalendarControllerTest < ActionController::TestCase
 
   def test_show_ics
     login_as(:admin_user)
-    get :show, :format => 'ics'
+    get :show, params: { :format => 'ics' }
     assert_equal 8, assigns['due_all'].count
   end
 
   def test_show_xml
     login_as(:admin_user)
-    get :show, :format => 'xml'
+    get :show, params: { :format => 'xml' }
     assert_equal 8, assigns['due_all'].count
   end
 end

--- a/test/controllers/contexts_controller_test.rb
+++ b/test/controllers/contexts_controller_test.rb
@@ -13,7 +13,7 @@ class ContextsControllerTest < ActionController::TestCase
   
   def test_show_sets_title
     login_as :admin_user
-    get :show, { :id => "1" }
+    get :show, params: { :id => "1" }
     assert_equal 'TRACKS::Context: agenda', assigns['page_title']
   end
 
@@ -23,19 +23,19 @@ class ContextsControllerTest < ActionController::TestCase
     assert_equal 6, todos.size
     c.hide!
     login_as :admin_user
-    get :show, { :id => '1'}
+    get :show, params: { :id => '1'}
     assert_equal 6, assigns['not_done_todos'].size
   end
 
   def test_show_renders_show_template
     login_as :admin_user
-    get :show, { :id => "1" }
+    get :show, params: { :id => "1" }
     assert_template "contexts/show"
   end
   
   def test_get_edit_form_using_xhr
     login_as(:admin_user)
-    xhr :get, :edit, :id => contexts(:errand).id
+    get :edit, xhr: true, params: { :id => contexts(:errand).id }
     assert_response 200
   end
 
@@ -47,7 +47,7 @@ class ContextsControllerTest < ActionController::TestCase
   def test_update_handles_invalid_state_change
     login_as :admin_user
     context = users(:admin_user).contexts.first
-    xhr :put, :update, :id => context.id, :context => {:name => "@name", :state => 'closed'}
+    put :update, xhr: true, params: { :id => context.id, :context => {:name => "@name", :state => 'closed'} }
 
     assert_response 200
     assert /The context cannot be closed if you have uncompleted actions/.match(@response.body)
@@ -57,26 +57,26 @@ class ContextsControllerTest < ActionController::TestCase
   
   def test_text_feed_content
     login_as :admin_user
-    get :index, { :format => "txt" }
+    get :index, params: { :format => "txt" }
     assert_equal 'text/plain', @response.content_type
     assert !(/&nbsp;/.match(@response.body))
   end
   
   def test_text_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "txt" }
+    get :index, params: { :format => "txt" }
     assert_response 401
   end
   
   def test_text_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "txt", :token => 'foo'  }
+    get :index, params: { :format => "txt", :token => 'foo'  }
     assert_response 401
   end
   
   def test_text_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "txt", :token => users(:admin_user).token }
+    get :index, params: { :format => "txt", :token => users(:admin_user).token }
     assert_response :ok
   end
 
@@ -84,20 +84,20 @@ class ContextsControllerTest < ActionController::TestCase
   
   def test_show_xml_renders_context_to_xml
     login_as :admin_user
-    get :show, { :id => "1", :format => 'xml' }
+    get :show, params: { :id => "1", :format => 'xml' }
     assert_equal contexts(:agenda).to_xml( :except => :user_id ), @response.body
   end
   
   def test_show_with_nil_context_returns_404
     login_as :admin_user
-    get :show, { :id => "0" }
+    get :show, params: { :id => "0" }
     assert_equal 'Context not found', @response.body
     assert_response 404
   end
   
   def test_show_xml_with_nil_context_returns_404
     login_as :admin_user
-    get :show, { :id => "0", :format => 'xml' }
+    get :show, params: { :id => "0", :format => 'xml' }
     assert_response 404
     assert_select 'error', 'Context not found'
   end
@@ -106,7 +106,7 @@ class ContextsControllerTest < ActionController::TestCase
 
   def test_rss_feed_content
     login_as :admin_user
-    get :index, { :format => "rss" }
+    get :index, params: { :format => "rss" }
     assert_equal 'application/rss+xml', @response.content_type
     #puts @response.body
   
@@ -134,19 +134,19 @@ class ContextsControllerTest < ActionController::TestCase
   
   def test_rss_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "rss" }
+    get :index, params: { :format => "rss" }
     assert_response 401
   end
   
   def test_rss_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "rss", :token => 'foo'  }
+    get :index, params: { :format => "rss", :token => 'foo'  }
     assert_response 401
   end
   
   def test_rss_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "rss", :token => users(:admin_user).token }
+    get :index, params: { :format => "rss", :token => users(:admin_user).token }
     assert_response :ok
   end
 
@@ -154,7 +154,7 @@ class ContextsControllerTest < ActionController::TestCase
   
   def test_atom_feed_content
     login_as :admin_user
-    get :index, { :format => "atom" }
+    get :index, params: { :format => "atom" }
     assert_equal 'application/atom+xml', @response.content_type
     assert_equal 'http://www.w3.org/2005/Atom', html_document.children[0].namespace.href
     assert_select 'feed' do
@@ -174,19 +174,19 @@ class ContextsControllerTest < ActionController::TestCase
  
   def test_atom_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "atom" }
+    get :index, params: { :format => "atom" }
     assert_response 401
   end
   
   def test_atom_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "atom", :token => 'foo'  }
+    get :index, params: { :format => "atom", :token => 'foo'  }
     assert_response 401
   end
   
   def test_atom_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "atom", :token => users(:admin_user).token }
+    get :index, params: { :format => "atom", :token => users(:admin_user).token }
     assert_response :ok
   end
 

--- a/test/controllers/feedlist_controller_test.rb
+++ b/test/controllers/feedlist_controller_test.rb
@@ -16,13 +16,13 @@ class FeedlistControllerTest < ActionController::TestCase
   
   def test_get_feeds_for_context_using_xhr
     login_as(:admin_user)
-    xhr :get, :get_feeds_for_context, :context_id => contexts(:errand).id
+    get :get_feeds_for_context, xhr: true, params: { :context_id => contexts(:errand).id }
     assert_response 200
   end
   
   def test_get_feeds_for_project_using_xhr
     login_as(:admin_user)
-    xhr :get, :get_feeds_for_project, :project_id => projects(:timemachine).id
+    get :get_feeds_for_project, xhr: true, params: { :project_id => projects(:timemachine).id }
     assert_response 200
   end
     

--- a/test/controllers/integrations_controller_test.rb
+++ b/test/controllers/integrations_controller_test.rb
@@ -17,7 +17,7 @@ class IntegrationsControllerTest < ActionController::TestCase
     stub_site_config do
       SITE_CONFIG['cloudmailin'] = "123456789"
       SITE_CONFIG['email_dispatch'] = 'from'
-      post :cloudmailin, {
+      post :cloudmailin, params: {
         "html"=>"",
         "plain"=>"asdasd",
         "x_to_header"=>"[\"81496ecea21032d35a7a@cloudmailin.net\"]",
@@ -37,7 +37,7 @@ class IntegrationsControllerTest < ActionController::TestCase
   def test_cloudmailin_integration_invalid_signature
     stub_site_config do
       SITE_CONFIG['cloudmailin'] = "12345678901234567890"
-      post :cloudmailin, {
+      post :cloudmailin, params: {
         "html"=>"",
         "plain"=>"asdasd",
         "x_to_header"=>"[\"81496ecea21032d35a7a@cloudmailin.net\"]",
@@ -57,7 +57,7 @@ class IntegrationsControllerTest < ActionController::TestCase
   def test_cloudmailin_integration_unknown_address
     stub_site_config do
       SITE_CONFIG['cloudmailin'] = "123456789"
-      post :cloudmailin, {
+      post :cloudmailin, params: {
         "html"=>"",
         "plain"=>"asdasd",
         "x_to_header"=>"[\"81496ecea21032d35a7a@cloudmailin.net\"]",

--- a/test/controllers/login_controller_test.rb
+++ b/test/controllers/login_controller_test.rb
@@ -11,7 +11,7 @@ class LoginControllerTest < ActionController::TestCase
   #============================================
     
   def test_invalid_login
-    post :login, {:user_login => 'cracker', :user_password => 'secret', :user_noexpiry => 'on'}
+    post :login, params: {:user_login => 'cracker', :user_password => 'secret', :user_noexpiry => 'on'}
     assert_response :success
     assert(!session[:user_id])
     assert_template "login"
@@ -19,7 +19,7 @@ class LoginControllerTest < ActionController::TestCase
   
   def test_login_with_valid_admin_user
     @request.session['return-to'] = "/bogus/location"
-    post :login, {:user_login => 'admin', :user_password => 'abracadabra', :user_noexpiry => 'on'}
+    post :login, params: {:user_login => 'admin', :user_password => 'abracadabra', :user_noexpiry => 'on'}
     user = User.find(session['user_id'])
     assert_not_nil user
     assert_equal user.id, session['user_id']
@@ -30,7 +30,7 @@ class LoginControllerTest < ActionController::TestCase
   end
   
   def test_login_with_valid_standard_user
-    post :login, {:user_login => 'jane', :user_password => 'sesame', :user_noexpiry => 'off'}
+    post :login, params: {:user_login => 'jane', :user_password => 'sesame', :user_noexpiry => 'off'}
     user = User.find(session['user_id'])
     assert_not_nil user
     assert_equal user.id, session['user_id']
@@ -56,26 +56,26 @@ class LoginControllerTest < ActionController::TestCase
   # Test login with a bad password for existing user
   #
   def test_login_bad_password
-    post :login, {:user_login => 'jane', :user_password => 'wrong', :user_noexpiry => 'on'}
+    post :login, params: {:user_login => 'jane', :user_password => 'wrong', :user_noexpiry => 'on'}
     assert(!session[:user])
     assert_equal "Login unsuccessful.", flash[:warning]
     assert_response :success
   end
   
   def test_login_bad_login
-    post :login, {:user_login => 'blah', :user_password => 'sesame', :user_noexpiry => 'on'}
+    post :login, params: {:user_login => 'blah', :user_password => 'sesame', :user_noexpiry => 'on'}
     assert(!session[:user])
     assert_equal "Login unsuccessful.", flash[:warning]
     assert_response :success
   end
   
   def test_should_remember_me
-    post :login, :user_login => 'jane', :user_password => 'sesame', :user_noexpiry => "on"
+    post :login, params: { :user_login => 'jane', :user_password => 'sesame', :user_noexpiry => "on" }
     assert_not_nil @response.cookies["auth_token"]
   end
   
   def test_should_not_remember_me
-    post :login, :user_login => 'jane', :user_password => 'sesame', :user_noexpiry => "off"
+    post :login, params: { :user_login => 'jane', :user_password => 'sesame', :user_noexpiry => "off" }
     assert_nil @response.cookies["auth_token"]
   end
   
@@ -113,7 +113,7 @@ class LoginControllerTest < ActionController::TestCase
   end
   
   def test_current_user_correct
-    post :login, {:user_login => 'jane', :user_password => 'sesame', :user_noexpiry => 'off'}
+    post :login, params: {:user_login => 'jane', :user_password => 'sesame', :user_noexpiry => 'off'}
     assert_equal users(:other_user), @controller.current_user
   end
   
@@ -124,7 +124,7 @@ class LoginControllerTest < ActionController::TestCase
   end
   
   def test_prefs_correct
-    post :login, {:user_login => 'jane', :user_password => 'sesame', :user_noexpiry => 'off'}
+    post :login, params: {:user_login => 'jane', :user_password => 'sesame', :user_noexpiry => 'off'}
     assert_equal users(:other_user).prefs, @controller.prefs
   end
   

--- a/test/controllers/mailgun_controller_test.rb
+++ b/test/controllers/mailgun_controller_test.rb
@@ -18,7 +18,7 @@ class MailgunControllerTest < ActionController::TestCase
       SITE_CONFIG['mailgun_api_key'] = "123456789"
       SITE_CONFIG['email_dispatch']  = 'from'
 
-      post :mailgun, {
+      post :mailgun, params: {
         "timestamp" => "1379539674",
         "token"     => "5km6cwo0e3bfvg78hw4s69znro09xhk1h8u6-s633yasc8hcr5",
         "signature" => "da92708b8f2c9dcd7ecdc91d52946c01802833e6683e46fc00b3f081920dd5b1",
@@ -38,7 +38,7 @@ class MailgunControllerTest < ActionController::TestCase
       }
 
       todo_count = Todo.count
-      post :mailgun, {
+      post :mailgun, params: {
         "timestamp" => "1379539674",
         "token"     => "5km6cwo0e3bfvg78hw4s69znro09xhk1h8u6-s633yasc8hcr5",
         "signature" => "da92708b8f2c9dcd7ecdc91d52946c01802833e6683e46fc00b3f081920dd5b1",
@@ -60,7 +60,7 @@ class MailgunControllerTest < ActionController::TestCase
       SITE_CONFIG['mailgun_api_key'] = "invalidkey"
       SITE_CONFIG['email_dispatch']  = 'from'
 
-      post :mailgun, {
+      post :mailgun, params: {
         "timestamp" => "1379539674",
         "token"     => "5km6cwo0e3bfvg78hw4s69znro09xhk1h8u6-s633yasc8hcr5",
         "signature" => "da92708b8f2c9dcd7ecdc91d52946c01802833e6683e46fc00b3f081920dd5b1",

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -13,7 +13,7 @@ class NotesControllerTest < ActionController::TestCase
     project = users(:admin_user).projects.first
     count = users(:admin_user).notes.count
 
-    post :create, note: {body: "test note", project_id: project.id}, format: :js
+    post :create, params: { note: {body: "test note", project_id: project.id}, format: :js }
 
     assert_response 200
     assert assigns['saved'], "@saved should be true"
@@ -26,7 +26,7 @@ class NotesControllerTest < ActionController::TestCase
     note = users(:admin_user).notes.first
 
     refute_equal "test", note.body
-    post :update, id: note.id, note: {body: "test"}, format: :js
+    post :update, params: { id: note.id, note: {body: "test"}, format: :js }
     assert_equal "test", note.reload.body
   end
 
@@ -36,7 +36,7 @@ class NotesControllerTest < ActionController::TestCase
     note = users(:admin_user).notes.first
     count = users(:admin_user).notes.count
 
-    post :destroy, id: note.id, format: :js
+    post :destroy, params: { id: note.id, format: :js }
 
     old_note = users(:admin_user).notes.where(id: note.id).first
     assert_nil old_note

--- a/test/controllers/preferences_controller_test.rb
+++ b/test/controllers/preferences_controller_test.rb
@@ -14,7 +14,7 @@ class PreferencesControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal I18n.l(Date.current, :format => "%Y-%m-%d"), @response.body
 
-    get(:render_date_format, {:date_format => "%A %Y"})
+    get :render_date_format, params: {:date_format => "%A %Y"}
     assert_response :success
     assert_equal I18n.l(Date.current, :format => "%A %Y"), @response.body
   end
@@ -35,7 +35,7 @@ class PreferencesControllerTest < ActionController::TestCase
 
   test "should update preferences" do
     login_as :admin_user
-    post :update, {
+    post :update, params: {
       :id => users(:admin_user).id,
       :user => { :first_name => 'Jane', :last_name => 'Doe'},
       :prefs => { :date_format => "%m-%d-%Y", :week_starts => "0", :show_number_completed => "10", :show_completed_projects_in_sidebar => "false", :show_hidden_contexts_in_sidebar => "false", :staleness_starts => "14", :due_style => "1" }}
@@ -51,7 +51,7 @@ class PreferencesControllerTest < ActionController::TestCase
 
     old_password_hash = users(:admin_user).password
 
-    post :update, {
+    post :update, params: {
       :id => users(:admin_user).id,
       :user => { :first_name => 'Jane', :last_name => 'Doe', :password => "", :password_confirmation => ""},
       :prefs => { :date_format => "%m-%d-%Y", :week_starts => "0", :show_number_completed => "10", :show_completed_projects_in_sidebar => "false", :show_hidden_contexts_in_sidebar => "false", :staleness_starts => "14", :due_style => "1" }}

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -15,7 +15,7 @@ class ProjectsControllerTest < ActionController::TestCase
   def test_show_exposes_deferred_todos
     p = projects(:timemachine)
     login_as :admin_user
-    get :show, :id => p.to_param
+    get :show, params: { :id => p.to_param }
     assert_not_nil assigns['deferred_todos']
     assert_equal 1, assigns['deferred_todos'].size
 
@@ -23,7 +23,7 @@ class ProjectsControllerTest < ActionController::TestCase
     t.show_from = 1.days.from_now.utc
     t.save!
 
-    get :show, :id => p.to_param
+    get :show, params: { :id => p.to_param }
     assert_equal 2, assigns['deferred_todos'].size
   end
 
@@ -39,13 +39,13 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_show_exposes_next_project_in_same_state
     login_as :admin_user
-    get :show, :id => projects(:timemachine).to_param
+    get :show, params: { :id => projects(:timemachine).to_param }
     assert_equal(projects(:moremoney), assigns['next_project'])
   end
 
   def test_show_exposes_previous_project_in_same_state
     login_as :admin_user
-    get :show, :id => projects(:moremoney).to_param
+    get :show, params: { :id => projects(:moremoney).to_param }
     assert_equal(projects(:timemachine), assigns['previous_project'])
   end
 
@@ -58,7 +58,7 @@ class ProjectsControllerTest < ActionController::TestCase
     p = projects(:timemachine)
     todos = p.todos.active
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, "project"=>{"name"=>p.name, "description"=>p.description, "state"=>"hidden"}
+    post :update, xhr: true, params: { :id => 1, "project"=>{"name"=>p.name, "description"=>p.description, "state"=>"hidden"} }
     todos.each do |t|
       assert t.reload().hidden?
     end
@@ -69,8 +69,8 @@ class ProjectsControllerTest < ActionController::TestCase
     p = projects(:timemachine)
     todos = p.todos.active
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, "project"=>{"name"=>p.name, "description"=>p.description, "state"=>"hidden"}
-    xhr :post, :update, :id => 1, "project"=>{"name"=>p.name, "description"=>p.description, "state"=>"active"}
+    post :update, xhr: true, params: { :id => 1, "project"=>{"name"=>p.name, "description"=>p.description, "state"=>"hidden"} }
+    post :update, xhr: true, params: { :id => 1, "project"=>{"name"=>p.name, "description"=>p.description, "state"=>"active"} }
     todos.each do |t|
       assert_equal :active, t.reload().aasm.current_state
     end
@@ -81,7 +81,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_rss_feed_content
     login_as(:admin_user)
-    get :index, { :format => "rss" }
+    get :index, params: { :format => "rss" }
     assert_equal 'application/rss+xml', @response.content_type
     #puts @response.body
 
@@ -109,25 +109,25 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_rss_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "rss" }
+    get :index, params: { :format => "rss" }
     assert_response 401
   end
 
   def test_rss_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "rss", :token => 'foo'  }
+    get :index, params: { :format => "rss", :token => 'foo'  }
     assert_response 401
   end
 
   def test_rss_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "rss", :token => users(:admin_user).token }
+    get :index, params: { :format => "rss", :token => users(:admin_user).token }
     assert_response :ok
   end
 
   def test_atom_feed_content
     login_as :admin_user
-    get :index, { :format => "atom" }
+    get :index, params: { :format => "atom" }
     assert_equal 'application/atom+xml', @response.content_type
     assert_equal 'http://www.w3.org/2005/Atom', html_document.children[0].namespace.href
     assert_select 'feed' do
@@ -147,25 +147,25 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_atom_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "atom" }
+    get :index, params: { :format => "atom" }
     assert_response 401
   end
 
   def test_atom_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "atom", :token => 'foo'  }
+    get :index, params: { :format => "atom", :token => 'foo'  }
     assert_response 401
   end
 
   def test_atom_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "atom", :token => users(:admin_user).token }
+    get :index, params: { :format => "atom", :token => users(:admin_user).token }
     assert_response :ok
   end
 
   def test_text_feed_content
     login_as :admin_user
-    get :index, { :format => "txt" }
+    get :index, params: { :format => "txt" }
     assert_equal 'text/plain', @response.content_type
     assert !(/&nbsp;/.match(@response.body))
   end
@@ -175,33 +175,33 @@ class ProjectsControllerTest < ActionController::TestCase
     p = projects(:timemachine)
     p.todos.each(&:destroy)
 
-    get :index, { :format => "txt", :only_active_with_no_next_actions => true }
+    get :index, params: { :format => "txt", :only_active_with_no_next_actions => true }
     assert (/^\s*BUILD A WORKING TIME MACHINE\s+0 actions. Project is active.\s*$/.match(@response.body))
     assert !(/[1-9] actions/.match(@response.body))
   end
 
   def test_text_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "txt" }
+    get :index, params: { :format => "txt" }
     assert_response 401
   end
 
   def test_text_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "txt", :token => 'foo'  }
+    get :index, params: { :format => "txt", :token => 'foo'  }
     assert_response 401
   end
 
   def test_text_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "txt", :token => users(:admin_user).token }
+    get :index, params: { :format => "txt", :token => users(:admin_user).token }
     assert_response :ok
   end
 
   def test_actionize_sorts_active_projects_by_number_of_tasks
     login_as :admin_user
     u = users(:admin_user)
-    post :actionize, :state => "active", :format => 'js'
+    post :actionize, params: { :state => "active", :format => 'js' }
 
     assert_equal 1, projects(:gardenclean).position
     assert_equal 2, projects(:moremoney).position
@@ -211,7 +211,7 @@ class ProjectsControllerTest < ActionController::TestCase
   def test_alphabetize_sorts_active_projects_alphabetically
     login_as :admin_user
     u = users(:admin_user)
-    post :alphabetize, :state => "active", :format => 'js'
+    post :alphabetize, params: { :state => "active", :format => 'js' }
     assert_equal 1, projects(:timemachine).position
     assert_equal 2, projects(:gardenclean).position
     assert_equal 3, projects(:moremoney).position
@@ -219,13 +219,13 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_alphabetize_assigns_state
     login_as :admin_user
-    post :alphabetize, :state => "active", :format => 'js'
+    post :alphabetize, params: { :state => "active", :format => 'js' }
     assert_equal "active", assigns['state']
   end
 
   def test_alphabetize_assigns_projects
     login_as :admin_user
-    post :alphabetize, :state => "active", :format => 'js'
+    post :alphabetize, params: { :state => "active", :format => 'js' }
     exposed_projects = assigns['projects']
     assert_equal 3, exposed_projects.length
     assert_equal projects(:timemachine), exposed_projects[0]
@@ -237,7 +237,7 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_xml_content
     login_as(:admin_user)
-    get :index, { :format => "xml" }
+    get :index, params: { :format => "xml" }
     assert_equal 'application/xml', @response.content_type
 
     assert_select 'projects' do
@@ -250,19 +250,19 @@ class ProjectsControllerTest < ActionController::TestCase
 
   def test_xml_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "xml" }
+    get :index, params: { :format => "xml" }
     assert_response 401
   end
 
   def test_xml_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "xml", :token => 'foo'  }
+    get :index, params: { :format => "xml", :token => 'foo'  }
     assert_response 401
   end
 
   def test_xml_not_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "xml", :token => users(:admin_user).token }
+    get :index, params: { :format => "xml", :token => users(:admin_user).token }
     assert_response 401
   end
 

--- a/test/controllers/recurring_todos_controller_test.rb
+++ b/test/controllers/recurring_todos_controller_test.rb
@@ -117,7 +117,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     # check error message
     errors = assigns(:recurring_todo).errors
     assert_equal 1, errors.size
-    assert_equal errors.get(:description), ["can't be blank"]
+    assert_equal errors[:description], ["can't be blank"]
   end
 
   def test_new_recurring_todo_handles_attribs_outside_rec_todo

--- a/test/controllers/recurring_todos_controller_test.rb
+++ b/test/controllers/recurring_todos_controller_test.rb
@@ -13,7 +13,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     rc = RecurringTodo.find(1)
     todo = rc.todos.first
 
-    xhr :post, :destroy, :id => 1, :_source_view => 'todo'
+    post :destroy, xhr: true, params: { :id => 1, :_source_view => 'todo' }
 
     begin
       rc = RecurringTodo.find(1)
@@ -30,7 +30,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
     orig_rt_count = RecurringTodo.count
     orig_todo_count = Todo.count
-    put :create,
+    put :create, params: {
       "context_name"=>"library",
       "project_name"=>"Build a working time machine",
       "recurring_todo" =>
@@ -63,6 +63,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
       "yearly_selector"=>"yearly_every_x_day"
     },
       "tag_list"=>"one, two, three, four", :format => :js
+    }
 
     # check new recurring todo added
     assert_equal orig_rt_count+1, RecurringTodo.count
@@ -74,7 +75,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
     orig_rt_count = RecurringTodo.count
     orig_todo_count = Todo.count
-    put :create,
+    put :create, params: {
       "context_name"=>"library",
       "project_name"=>"Build a working time machine",
       "recurring_todo" =>
@@ -107,6 +108,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
       "yearly_selector"=>"yearly_every_x_day"
     },
       "tag_list"=>"one, two, three, four", :format => :js
+    }
 
     # check no new recurring todo added
     assert_equal orig_rt_count, RecurringTodo.count
@@ -124,7 +126,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     # check new rec todo is not there
     assert_nil RecurringTodo.where(:description => "new recurrence pattern").first
 
-    put :create,
+    put :create, params: {
       "context_name"=>"library",
       "project_name"=>"Build a working time machine",
       "recurring_todo" =>
@@ -157,6 +159,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
       "yearly_selector"=>"yearly_every_x_day"
     },
       "tag_list"=>"one, two, three, four", :format => :js
+    }
 
     new_rec_todo = RecurringTodo.where(:description => "new recurrence pattern").first
 
@@ -171,7 +174,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
 
     # mark as complete
-    xhr :post, :toggle_check, :id=>1, :_source_view=>""
+    post :toggle_check, xhr: true, params: { :id=>1, :_source_view=>"" }
     recurring_todo_1 = RecurringTodo.find(1)
     assert recurring_todo_1.completed?
 
@@ -183,7 +186,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     todo_count = Todo.count
 
     # mark as active
-    xhr :post, :toggle_check, :id=>1, :_source_view=>""
+    post :toggle_check, xhr: true, params: { :id=>1, :_source_view=>"" }
 
     recurring_todo_1 = RecurringTodo.find(1) # reload seems to not work
     assert recurring_todo_1.active?, "recurring todo should be active but is #{recurring_todo_1.aasm.current_state}"
@@ -213,8 +216,8 @@ class RecurringTodosControllerTest < ActionController::TestCase
     assert @yearly.save
 
     # toggle twice to force generation of new todo
-    xhr :post, :toggle_check, :id=>5, :_source_view=>""
-    xhr :post, :toggle_check, :id=>5, :_source_view=>""
+    post :toggle_check, xhr: true, params: { :id=>5, :_source_view=>"" }
+    post :toggle_check, xhr: true, params: { :id=>5, :_source_view=>"" }
 
     new_todo = Todo.where(:recurring_todo_id => 5).first
 
@@ -238,7 +241,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
       orig_rt_count = RecurringTodo.count
       orig_todo_count = Todo.count
 
-      put :create,
+      put :create, params: {
         "context_name"=>"library",
         "project_name"=>"Build a working time machine",
         "recurring_todo" =>
@@ -271,6 +274,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
         "yearly_selector"=>"yearly_every_xth_day"
       },
         "tag_list"=>"one, two, three, four", :format => :js
+      }
 
       # check new recurring todo added
       assert_equal orig_rt_count+1, RecurringTodo.count
@@ -292,7 +296,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     orig_rt_count = RecurringTodo.count
     orig_todo_count = Todo.count
 
-    put :create,
+    put :create, params: {
       "context_name"=>"library",
       "project_name"=>"Build a working time machine",
       "recurring_todo" =>
@@ -325,6 +329,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
       "yearly_selector"=>"yearly_every_xth_day"
     },
       "tag_list"=>"one, two, three, four", :format => :js
+    }
 
     # check new recurring todo added
     assert_equal orig_rt_count+1, RecurringTodo.count
@@ -344,7 +349,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
 
       login_as(:admin_user)
 
-      put :create,
+      put :create, params: {
         "context_name"=>"library",
         "project_name"=>"Build a working time machine",
         "recurring_todo" =>
@@ -377,6 +382,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
         "yearly_selector"=>"yearly_every_x_day"
       },
         "tag_list"=>"one, two, three, four", format: :js
+      }
 
       assert_equal "new recurrence pattern", assigns['recurring_todo'].description
       assert_equal "2013-01-02 00:00:00 +0000", assigns['recurring_todo'].start_from.to_s
@@ -419,7 +425,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
     rt = recurring_todos(:call_bill_gates_every_day)
 
-    put :update,
+    put :update, params: {
       "recurring_todo" => {
         "description"        => "changed",
         "daily_selector"     => "daily_every_x_day",
@@ -436,6 +442,7 @@ class RecurringTodosControllerTest < ActionController::TestCase
       "id"                             => "#{rt.id}",
       "context_name"                   => "library",
       format: :js
+    }
 
     assert_equal "changed", rt.reload.description
   end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -13,7 +13,7 @@ class SearchControllerTest < ActionController::TestCase
   
   def test_search_for_todo_with_tag
     login_as :admin_user
-    post :results, :search => "gates"
+    post :results, params: { :search => "gates" }
     assert_response 200
     assert_equal 3, assigns['count'], "should have found 3 todos"
   end

--- a/test/controllers/stats_controller_test.rb
+++ b/test/controllers/stats_controller_test.rb
@@ -69,22 +69,22 @@ class StatsControllerTest < ActionController::TestCase
     # assert_template nil
 
     # get week 0-1 for actions visible running
-    get :show_selected_actions_from_chart, :id => 'avrt', :index => 0
+    get :show_selected_actions_from_chart, params: { :id => 'avrt', :index => 0 }
     assert_response :success
     assert_template "stats/show_selection_from_chart"
 
     # get week 0 and further for actions visible running
-    get :show_selected_actions_from_chart, :id => 'avrt_end', :index => 0
+    get :show_selected_actions_from_chart, params: { :id => 'avrt_end', :index => 0 }
     assert_response :success
     assert_template "stats/show_selection_from_chart"
 
     # get week 0-1 for actions running
-    get :show_selected_actions_from_chart, :id => 'art', :index => 0
+    get :show_selected_actions_from_chart, params: { :id => 'art', :index => 0 }
     assert_response :success
     assert_template "stats/show_selection_from_chart"
 
     # get week 0 and further for actions running
-    get :show_selected_actions_from_chart, :id => 'art_end', :index => 0
+    get :show_selected_actions_from_chart, params: { :id => 'art_end', :index => 0 }
     assert_response :success
     assert_template "stats/show_selection_from_chart"
   end
@@ -404,7 +404,7 @@ class StatsControllerTest < ActionController::TestCase
     given_todos_for_stats
 
     # When I get the chart data
-    get :show_selected_actions_from_chart, {:id => "avrt", :index => 1}
+    get :show_selected_actions_from_chart, params: {:id => "avrt", :index => 1}
     assert_response :success
 
     assert_equal false, assigns['further']  # not at end
@@ -419,7 +419,7 @@ class StatsControllerTest < ActionController::TestCase
     given_todos_for_stats
 
     # When I get the chart data
-    get :show_selected_actions_from_chart, {:id => "avrt_end", :index => 1}
+    get :show_selected_actions_from_chart, params: {:id => "avrt_end", :index => 1}
     assert_response :success
 
     assert assigns['further']  # at end
@@ -434,7 +434,7 @@ class StatsControllerTest < ActionController::TestCase
     given_todos_for_stats
 
     # When I get the chart data
-    get :show_selected_actions_from_chart, {:id => "art", :index => 1}
+    get :show_selected_actions_from_chart, params: {:id => "art", :index => 1}
     assert_response :success
 
     assert_equal false, assigns['further']  # not at end
@@ -449,7 +449,7 @@ class StatsControllerTest < ActionController::TestCase
     given_todos_for_stats
 
     # When I get the chart data
-    get :show_selected_actions_from_chart, {:id => "art_end", :index => 1}
+    get :show_selected_actions_from_chart, params: {:id => "art_end", :index => 1}
     assert_response :success
 
     assert assigns['further']  # at end

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -63,9 +63,9 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_deferred_count_for_project_source_view
     login_as(:admin_user)
-    xhr :post, :toggle_check, :id => 5, :_source_view => 'project'
+    post :toggle_check, xhr: true, params: { :id => 5, :_source_view => 'project' }
     assert_equal 1, assigns['remaining_deferred_or_pending_count']
-    xhr :post, :toggle_check, :id => 15, :_source_view => 'project'
+    post :toggle_check, xhr: true, params: { :id => 15, :_source_view => 'project' }
     assert_equal 0, assigns['remaining_deferred_or_pending_count']
   end
 
@@ -86,9 +86,9 @@ class TodosControllerTest < ActionController::TestCase
     # by default has_many_polymorph searches for tags with given id if the tag is a number. we do not want that
     login_as(:admin_user)
     assert_difference 'Todo.count' do
-      put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
+      put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
         "notes"=>"", "description"=>"test tags", "due"=>"30/11/2006"},
-        "tag_list"=>"1234,5667,9876"
+        "tag_list"=>"1234,5667,9876" }
       # default has_many_polymorphs will fail on these high numbers as tags with those id's do not exist
     end
     t = assigns['todo']
@@ -100,9 +100,9 @@ class TodosControllerTest < ActionController::TestCase
     # by default has_many_polymorph searches for tags with given id if the tag is a number. we do not want that
     login_as(:admin_user)
     assert_difference 'Todo.count' do
-      put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
+      put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
         "notes"=>"", "description"=>"test tags", "due"=>"30/11/2006"},
-        "tag_list"=>"a,,b"
+        "tag_list"=>"a,,b" }
       # default has_many_polymorphs will fail on the empty tag
     end
     t = assigns['todo']
@@ -115,7 +115,7 @@ class TodosControllerTest < ActionController::TestCase
     @user = User.find(@request.session['user_id'])
     tag = Tag.where(:name => 'foo').first.taggings
     @tagged = tag.count
-    get :tag, :name => 'foo'
+    get :tag, params: { :name => 'foo' }
     assert_response :success
     assert_equal 3, @tagged
   end
@@ -126,17 +126,17 @@ class TodosControllerTest < ActionController::TestCase
     t = assigns['todo']
     assert_equal "first.last, second", t.tag_list
 
-    get :tag, name: 'first.last.m'
+    get :tag, params: { name: 'first.last.m' }
     assert_equal "text/html", request.format, "controller should set right content type"
     assert_equal "text/html", @response.content_type
     assert_equal "first.last", assigns['tag_name'], ".m should be chomped"
 
-    get :tag, name: 'first.last.txt'
+    get :tag, params: { name: 'first.last.txt' }
     assert_equal "text/plain", request.format, "controller should set right content type"
     assert_equal "text/plain", @response.content_type
     assert_equal "first.last", assigns['tag_name'], ".txt should be chomped"
 
-    get :tag, name: 'first.last'
+    get :tag, params: { name: 'first.last' }
     assert_equal "text/html", request.format, "controller should set right content type"
     assert_equal "text/html", @response.content_type
     assert_equal "first.last", assigns['tag_name'], ":name should be correct"
@@ -144,7 +144,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_get_boolean_expression_from_parameters_of_tag_view_single_tag
     login_as(:admin_user)
-    get :tag, :name => "single"
+    get :tag, params: { :name => "single" }
     assert_equal true, assigns['single_tag'], "should recognize it is a single tag name"
     assert_equal "single", assigns['tag_expr'][0][0], "should store the single tag"
     assert_equal "single", assigns['tag_name'], "should store the single tag name"
@@ -152,21 +152,21 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_get_boolean_expression_from_parameters_of_tag_view_multiple_tags
     login_as(:admin_user)
-    get :tag, :name => "multiple", :and => "tags", :and1 => "present", :and2 => "here"
+    get :tag, params: { :name => "multiple", :and => "tags", :and1 => "present", :and2 => "here" }
     assert_equal false, assigns['single_tag'], "should recognize it has multiple tags"
     assert_equal 4, assigns['tag_expr'].size, "should have 4 AND expressions"
   end
 
   def test_get_boolean_expression_from_parameters_of_tag_view_multiple_tags_without_digitless_and
     login_as(:admin_user)
-    get :tag, :name => "multiple", :and1 => "tags", :and2 => "present", :and3 => "here"
+    get :tag, params: { :name => "multiple", :and1 => "tags", :and2 => "present", :and3 => "here" }
     assert_equal false, assigns['single_tag'], "should recognize it has multiple tags"
     assert_equal 4, assigns['tag_expr'].size, "should have 4 AND expressions"
   end
 
   def test_get_boolean_expression_from_parameters_of_tag_view_multiple_ORs
     login_as(:admin_user)
-    get :tag, :name => "multiple,tags,present"
+    get :tag, params: { :name => "multiple,tags,present" }
     assert_equal false, assigns['single_tag'], "should recognize it has multiple tags"
     assert_equal 1, assigns['tag_expr'].size, "should have 1 expressions"
     assert_equal 3, assigns['tag_expr'][0].size, "should have 3 ORs in 1st expression"
@@ -174,7 +174,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_get_boolean_expression_from_parameters_of_tag_view_multiple_ORs_and_ANDS
     login_as(:admin_user)
-    get :tag, :name => "multiple,tags,present", :and => "here,is,two", :and1=>"and,three"
+    get :tag, params: { :name => "multiple,tags,present", :and => "here,is,two", :and1=>"and,three" }
     assert_equal false, assigns['single_tag'], "should recognize it has multiple tags"
     assert_equal 3, assigns['tag_expr'].size, "should have 3 expressions"
     assert_equal 3, assigns['tag_expr'][0].size, "should have 3 ORs in 1st expression"
@@ -185,18 +185,18 @@ class TodosControllerTest < ActionController::TestCase
   def test_set_right_title_tag_page
     login_as(:admin_user)
 
-    get :tag, :name => "foo"
+    get :tag, params: { :name => "foo" }
     assert_equal "foo", assigns['tag_title']
-    get :tag, :name => "foo,bar", :and => "baz"
+    get :tag, params: { :name => "foo,bar", :and => "baz" }
     assert_equal "foo,bar AND baz", assigns['tag_title']
   end
 
   def test_set_default_tag
     login_as(:admin_user)
 
-    get :tag, :name => "foo"
+    get :tag, params: { :name => "foo" }
     assert_equal "foo", assigns['initial_tags']
-    get :tag, :name => "foo,bar", :and => "baz"
+    get :tag, params: { :name => "foo,bar", :and => "baz" }
     assert_equal "foo", assigns['initial_tags']
   end
 
@@ -207,14 +207,14 @@ class TodosControllerTest < ActionController::TestCase
   def test_create_todo
     assert_difference 'Todo.count' do
       login_as(:admin_user)
-      put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar"
+      put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar" }
     end
   end
 
   def test_create_todo_via_xml
     login_as(:admin_user)
     assert_difference 'Todo.count' do
-      put :create, :format => "xml", "request" => { "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar" }
+      put :create, params: { :format => "xml", "request" => { "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar" } }
       assert_response 201
     end
   end
@@ -222,7 +222,16 @@ class TodosControllerTest < ActionController::TestCase
   def test_create_todo_via_xhr
     login_as(:admin_user)
     assert_difference 'Todo.count' do
-      xhr :put, :create, "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar"
+      put :create, xhr: true, params: {
+        "context_name"=>"library",
+        "project_name"=>"Build a working time machine",
+        "todo" => {
+          "notes"=>"",
+          "description" => "Call Warren Buffet to find out how much he makes per day",
+          "due"=>"30/11/2006"
+        },
+        "tag_list"=>"foo bar"
+      }
       assert_response 200
     end
   end
@@ -230,9 +239,9 @@ class TodosControllerTest < ActionController::TestCase
   def test_fail_to_create_todo_via_xml
     login_as(:admin_user)
     # try to create with no context, which is not valid
-    put :create, :format => "xml", "request" => {
+    put :create, params: { :format => "xml", "request" => {
       "project_name"=>"Build a working time machine",
-      "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar" }
+      "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar" } }
     assert_response 409
     assert_select "errors" do
       assert_select "error", "Context can't be blank"
@@ -242,7 +251,7 @@ class TodosControllerTest < ActionController::TestCase
   def test_create_deferred_todo
     original_todo_count = Todo.count
     login_as(:admin_user)
-    put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2026", 'show_from' => '30/10/2026'}, "tag_list"=>"foo bar"
+    put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2026", 'show_from' => '30/10/2026'}, "tag_list"=>"foo bar" }
     assert_equal original_todo_count + 1, Todo.count
   end
 
@@ -250,8 +259,8 @@ class TodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
 
     start_count = Todo.count
-    put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
-      :multiple_todos=>"a\nb\nmuch \"ado\" about \'nothing\'"}
+    put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
+      :multiple_todos=>"a\nb\nmuch \"ado\" about \'nothing\'"} }
 
     assert_equal start_count+3, Todo.count, "two todos should have been added"
   end
@@ -262,8 +271,8 @@ class TodosControllerTest < ActionController::TestCase
     long_string = "a" * 500
 
     start_count = Todo.count
-    put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
-      :multiple_todos=>"a\nb\nmuch \"ado\" about \'nothing\'\n#{long_string}"}
+    put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
+      :multiple_todos=>"a\nb\nmuch \"ado\" about \'nothing\'\n#{long_string}"} }
 
     assert_equal start_count, Todo.count, "no todos should have been added"
   end
@@ -272,10 +281,10 @@ class TodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
 
     start_count = Todo.count
-    put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
-      :multiple_todos=>"a\nb"}, :todos_sequential => 'true'
-    put :create, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
-      :multiple_todos=>"c\nd"}, :todos_sequential => 'false'
+    put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
+      :multiple_todos=>"a\nb"}, :todos_sequential => 'true' }
+    put :create, params: { :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{
+      :multiple_todos=>"c\nd"}, :todos_sequential => 'false' }
 
     assert_equal start_count+4, Todo.count, "four todos should have been added"
 
@@ -295,7 +304,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_destroy_todo
     login_as(:admin_user)
-    xhr :post, :destroy, :id => 1, :_source_view => 'todo'
+    post :destroy, xhr: true, params: { :id => 1, :_source_view => 'todo' }
     todo = Todo.where(:id=>1).first
     assert_nil todo
   end
@@ -306,14 +315,14 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_get_edit_form_using_xhr
     login_as(:admin_user)
-    xhr :get, :edit, :id => todos(:call_bill).id
+    get :edit, xhr: true, params: { :id => todos(:call_bill).id }
     assert_response 200
   end
 
   def test_update_todo_project
     t = Todo.find(1)
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar"
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Build a working time machine", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar" }
     t = Todo.find(1)
     assert_equal 1, t.project_id
   end
@@ -321,7 +330,7 @@ class TodosControllerTest < ActionController::TestCase
   def test_update_todo_delete_project
     t = Todo.find(1)
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar"
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo bar" }
     t = Todo.find(1)
     assert_nil t.project_id
   end
@@ -330,14 +339,14 @@ class TodosControllerTest < ActionController::TestCase
     login_as(:admin_user)
     get :index
     assert_equal 11, assigns['count']
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Make more money than Billy Gates", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006", "show_from"=>"30/11/2030"}, "tag_list"=>"foo bar"
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "context_name"=>"library", "project_name"=>"Make more money than Billy Gates", "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006", "show_from"=>"30/11/2030"}, "tag_list"=>"foo bar" }
     assert_equal 10, assigns['down_count']
   end
 
   def test_update_todo
     t = Todo.find(1)
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "todo"=>{"context_id"=>"1", "project_id"=>"2", "id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo, bar"
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "todo"=>{"context_id"=>"1", "project_id"=>"2", "id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo, bar" }
     t = Todo.find(1)
     assert_equal "Call Warren Buffet to find out how much he makes per day", t.description
     assert_equal "bar, foo", t.tag_list
@@ -349,7 +358,7 @@ class TodosControllerTest < ActionController::TestCase
   def test_update_todos_with_blank_project_name
     t = Todo.find(1)
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', :project_name => '', "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo, bar"
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', :project_name => '', "todo"=>{"id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"foo, bar" }
     t.reload
     assert t.project.nil?
   end
@@ -357,7 +366,7 @@ class TodosControllerTest < ActionController::TestCase
   def test_update_todo_tags_to_none
     t = Todo.find(1)
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "todo"=>{"context_id"=>"1", "project_id"=>"2", "id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>""
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "todo"=>{"context_id"=>"1", "project_id"=>"2", "id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>"" }
     t = Todo.find(1)
     assert_equal true, t.tag_list.empty?
   end
@@ -366,7 +375,7 @@ class TodosControllerTest < ActionController::TestCase
     t = Todo.find(1)
     login_as(:admin_user)
     taglist = "  one  ,  two,three    ,four, 8.1.2, version1.5"
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "todo"=>{"context_id"=>"1", "project_id"=>"2", "id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>taglist
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "todo"=>{"context_id"=>"1", "project_id"=>"2", "id"=>"1", "notes"=>"", "description"=>"Call Warren Buffet to find out how much he makes per day", "due"=>"30/11/2006"}, "tag_list"=>taglist }
     t = Todo.find(1)
     assert_equal "8.1.2, four, one, three, two, version1.5", t.tag_list
   end
@@ -406,7 +415,7 @@ class TodosControllerTest < ActionController::TestCase
 
     refute_equal todo.context.id, context.id
 
-    xhr :post, :change_context, :id => todo.id, :todo=>{:context_id => context.id}, :_source_view=>"todo"
+    post :change_context, xhr: true, params: { :id => todo.id, :todo=>{:context_id => context.id}, :_source_view=>"todo" }
     assert assigns['context_changed'], "context should have changed"
     assert_equal todo.id, assigns['todo'].id, 'correct todo should have been found'
     assert_equal context.id, todo.reload.context.id, 'context of todo should be changed'
@@ -421,7 +430,7 @@ class TodosControllerTest < ActionController::TestCase
     t.show_from = "01/01/2030"
     assert t.deferred?
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "todo"=>{"show_from"=>""}, "tag_list"=>""
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "todo"=>{"show_from"=>""}, "tag_list"=>"" }
     t = Todo.find(1)
     assert t.active?
     assert_nil t.show_from
@@ -431,7 +440,7 @@ class TodosControllerTest < ActionController::TestCase
     t = Todo.find(1)
     assert t.active?
     login_as(:admin_user)
-    xhr :post, :update, :id => 1, :_source_view => 'todo', "todo"=>{"show_from"=>"01/01/2030"}, "tag_list"=>""
+    post :update, xhr: true, params: { :id => 1, :_source_view => 'todo', "todo"=>{"show_from"=>"01/01/2030"}, "tag_list"=>"" }
     t = Todo.find(1)
     assert t.deferred?
     assert_not_nil t.show_from
@@ -469,7 +478,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_rss_feed_not_completed
     login_as(:admin_user)
-    get :index, { :format => "rss" }
+    get :index, params: { :format => "rss" }
     assert_equal 'application/rss+xml', @response.content_type
     # puts @response.body
 
@@ -492,7 +501,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_atom_feed_not_completed
     login_as :admin_user
-    get :index, { :format => "atom" }
+    get :index, params: { :format => "atom" }
     assert_equal 'application/atom+xml', @response.content_type
     assert_equal 'http://www.w3.org/2005/Atom', html_document.children[0].namespace.href
     assert_select 'feed' do
@@ -508,7 +517,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_text_feed_not_completed
     login_as(:admin_user)
-    get :index, { :format => "txt" }
+    get :index, params: { :format => "txt" }
     assert_equal 'text/plain', @response.content_type
     assert !(/&nbsp;/.match(@response.body))
     assert_number_of_items_in_text_feed 11
@@ -516,7 +525,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_ical_feed_not_completed
     login_as :admin_user
-    get :index, { :format => "ics" }
+    get :index, params: { :format => "ics" }
     assert_equal 'text/calendar', @response.content_type
     assert !(/&nbsp;/.match(@response.body))
     assert_number_of_items_in_ical_feed 11
@@ -524,219 +533,219 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_rss_feed_completed_in_last_week
     login_as(:admin_user)
-    get :index, { :format => "rss", :done => '7' }
+    get :index, params: { :format => "rss", :done => '7' }
 
     assert_number_of_items_in_rss_feed 3
   end
 
   def test_atom_feed_completed_in_last_week
     login_as(:admin_user)
-    get :index, { :format => "atom", :done => '7' }
+    get :index, params: { :format => "atom", :done => '7' }
 
     assert_number_of_items_in_atom_feed 3
   end
 
   def test_text_feed_completed_in_last_week
     login_as(:admin_user)
-    get :index, { :format => "text", :done => '7' }
+    get :index, params: { :format => "text", :done => '7' }
 
     assert_number_of_items_in_text_feed 3
   end
 
   def test_ical_feed_completed_in_last_week
     login_as(:admin_user)
-    get :index, { :format => "ics", :done => '7' }
+    get :index, params: { :format => "ics", :done => '7' }
 
     assert_number_of_items_in_ical_feed 3
   end
 
   def test_rss_feed_with_limit
     login_as(:admin_user)
-    get :index, { :format => "rss", :limit => '5' }
+    get :index, params: { :format => "rss", :limit => '5' }
 
     assert_number_of_items_in_rss_feed 5
   end
 
   def test_atom_feed_with_limit
     login_as(:admin_user)
-    get :index, { :format => "atom", :limit => '5' }
+    get :index, params: { :format => "atom", :limit => '5' }
 
     assert_number_of_items_in_atom_feed 5
   end
 
   def test_text_feed_with_limit
     login_as(:admin_user)
-    get :index, { :format => "text", :limit => '5' }
+    get :index, params: { :format => "text", :limit => '5' }
 
     assert_number_of_items_in_text_feed 5
   end
 
   def test_ical_feed_with_limit
     login_as(:admin_user)
-    get :index, { :format => "ics", :limit => '5' }
+    get :index, params: { :format => "ics", :limit => '5' }
 
     assert_number_of_items_in_ical_feed 5
   end
 
   def test_rss_feed_filter_by_context
     login_as(:admin_user)
-    get :index, { :format => "rss", :context_id => 2 }
+    get :index, params: { :format => "rss", :context_id => 2 }
 
     assert_number_of_items_in_rss_feed 3
   end
 
   def test_atom_feed_filter_by_context
     login_as(:admin_user)
-    get :index, { :format => "atom", :context_id => 2 }
+    get :index, params: { :format => "atom", :context_id => 2 }
 
     assert_number_of_items_in_atom_feed 3
   end
 
   def test_text_feed_filter_by_context
     login_as(:admin_user)
-    get :index, { :format => "text", :context_id => 2 }
+    get :index, params: { :format => "text", :context_id => 2 }
 
     assert_number_of_items_in_text_feed 3
   end
 
   def test_ical_feed_filter_by_context
     login_as(:admin_user)
-    get :index, { :format => "ics", :context_id => 2 }
+    get :index, params: { :format => "ics", :context_id => 2 }
 
     assert_number_of_items_in_ical_feed 3
   end
 
   def test_rss_feed_filter_by_project
     login_as(:admin_user)
-    get :index, { :format => "rss", :project_id => 2 }
+    get :index, params: { :format => "rss", :project_id => 2 }
 
     assert_number_of_items_in_rss_feed 4
   end
 
   def test_atom_feed_filter_by_project
     login_as(:admin_user)
-    get :index, { :format => "atom", :project_id => 2 }
+    get :index, params: { :format => "atom", :project_id => 2 }
 
     assert_number_of_items_in_atom_feed 4
   end
 
   def test_text_feed_filter_by_project
     login_as(:admin_user)
-    get :index, { :format => "text", :project_id => 2 }
+    get :index, params: { :format => "text", :project_id => 2 }
 
     assert_number_of_items_in_text_feed 4
   end
 
   def test_ical_feed_filter_by_project
     login_as(:admin_user)
-    get :index, { :format => "ics", :project_id => 2 }
+    get :index, params: { :format => "ics", :project_id => 2 }
 
     assert_number_of_items_in_ical_feed 4
   end
 
   def test_rss_feed_filter_by_project_and_context
     login_as(:admin_user)
-    get :index, { :format => "rss", :project_id => 2, :context_id => 2 }
+    get :index, params: { :format => "rss", :project_id => 2, :context_id => 2 }
 
     assert_number_of_items_in_rss_feed 1
   end
 
   def test_atom_feed_filter_by_project_and_context
     login_as(:admin_user)
-    get :index, { :format => "atom", :project_id => 2, :context_id => 2 }
+    get :index, params: { :format => "atom", :project_id => 2, :context_id => 2 }
 
     assert_number_of_items_in_atom_feed 1
   end
 
   def test_text_feed_filter_by_project_and_context
     login_as(:admin_user)
-    get :index, { :format => "text", :project_id => 2, :context_id => 2 }
+    get :index, params: { :format => "text", :project_id => 2, :context_id => 2 }
 
     assert_number_of_items_in_text_feed 1
   end
 
   def test_ical_feed_filter_by_project_and_context
     login_as(:admin_user)
-    get :index, { :format => "ics", :project_id => 2, :context_id => 2 }
+    get :index, params: { :format => "ics", :project_id => 2, :context_id => 2 }
 
     assert_number_of_items_in_ical_feed 1
   end
 
   def test_rss_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "rss" }
+    get :index, params: { :format => "rss" }
     assert_response 401
   end
 
   def test_atom_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "atom" }
+    get :index, params: { :format => "atom" }
     assert_response 401
   end
 
   def test_text_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :index, { :format => "txt" }
+    get :index, params: { :format => "txt" }
     assert_response 401
   end
 
   def test_rss_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "rss", :token => 'foo'  }
+    get :index, params: { :format => "rss", :token => 'foo'  }
     assert_response 401
   end
 
   def test_atom_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "atom", :token => 'foo'  }
+    get :index, params: { :format => "atom", :token => 'foo'  }
     assert_response 401
   end
 
   def test_text_feed_not_accessible_to_anonymous_user_with_invalid_token
     login_as nil
-    get :index, { :format => "txt", :token => 'foo'  }
+    get :index, params: { :format => "txt", :token => 'foo'  }
     assert_response 401
   end
 
   def test_rss_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "rss", :token => users(:admin_user).token }
+    get :index, params: { :format => "rss", :token => users(:admin_user).token }
     assert_response :ok
   end
 
   def test_atom_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "atom", :token => users(:admin_user).token }
+    get :index, params: { :format => "atom", :token => users(:admin_user).token }
     assert_response :ok
   end
 
   def test_text_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "txt", :token => users(:admin_user).token }
+    get :index, params: { :format => "txt", :token => users(:admin_user).token }
     assert_response :ok
   end
 
   def test_ical_feed_accessible_to_anonymous_user_with_valid_token
     login_as nil
-    get :index, { :format => "ics", :token => users(:admin_user).token }
+    get :index, params: { :format => "ics", :token => users(:admin_user).token }
     assert_response :ok
   end
 
   def test_tag_rss_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :tag, {:name => "foo", :format => "rss" }
+    get :tag, params: {:name => "foo", :format => "rss" }
     assert_response 401
   end
 
   def test_tag_atom_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :tag, {:name => "foo", :format => "atom" }
+    get :tag, params: {:name => "foo", :format => "atom" }
     assert_response 401
   end
 
   def test_tag_text_feed_not_accessible_to_anonymous_user_without_token
     login_as nil
-    get :tag, {:name => "foo", :format => "txt" }
+    get :tag, params: {:name => "foo", :format => "txt" }
     assert_response 401
   end
 
@@ -746,18 +755,18 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_mobile_index_uses_text_html_content_type
     login_as(:admin_user)
-    get :index, { :format => "m" }
+    get :index, params: { :format => "m" }
     assert_equal 'text/html', @response.content_type
   end
 
   def test_mobile_index_assigns_down_count
     login_as(:admin_user)
-    get :index, { :format => "m" }
+    get :index, params: { :format => "m" }
     assert_equal 11, assigns['down_count']
   end
 
   def test_mobile_redirect_to_login
-    get :index, { :format => "m" }
+    get :index, params: { :format => "m" }
     assert_redirected_to login_url(:format => "m")
   end
 
@@ -767,7 +776,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_mobile_create_action_creates_a_new_todo
     login_as(:admin_user)
-    post :create, {"format"=>"m", "todo"=>{"context_id"=>"2",
+    post :create, params: {"format"=>"m", "todo"=>{"context_id"=>"2",
         "due(1i)"=>"2007", "due(2i)"=>"1", "due(3i)"=>"2",
         "show_from(1i)"=>"", "show_from(2i)"=>"", "show_from(3i)"=>"",
         "project_id"=>"1",
@@ -784,7 +793,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_mobile_create_action_redirects_to_mobile_home_page_when_successful
     login_as(:admin_user)
-    post :create, {"format"=>"m", "todo"=>{"context_id"=>"2",
+    post :create, params: {"format"=>"m", "todo"=>{"context_id"=>"2",
         "due(1i)"=>"2007", "due(2i)"=>"1", "due(3i)"=>"2",
         "show_from(1i)"=>"", "show_from(2i)"=>"", "show_from(3i)"=>"",
         "project_id"=>"1",
@@ -795,7 +804,7 @@ class TodosControllerTest < ActionController::TestCase
 
   def test_mobile_create_action_renders_new_template_when_save_fails
     login_as(:admin_user)
-    post :create, {"format"=>"m", "todo"=>{"context_id"=>"2",
+    post :create, params: {"format"=>"m", "todo"=>{"context_id"=>"2",
         "due(1i)"=>"2007", "due(2i)"=>"1", "due(3i)"=>"2",
         "show_from(1i)"=>"", "show_from(2i)"=>"", "show_from(3i)"=>"",
         "project_id"=>"1",
@@ -815,7 +824,7 @@ class TodosControllerTest < ActionController::TestCase
     todo_1 = Todo.where(:recurring_todo_id => 1).first
 
     # mark todo_1 as complete by toggle_check
-    xhr :post, :toggle_check, :id => todo_1.id, :_source_view => 'todo'
+    post :toggle_check, xhr: true, params: { :id => todo_1.id, :_source_view => 'todo' }
     todo_1.reload
     assert todo_1.completed?
 
@@ -844,7 +853,7 @@ class TodosControllerTest < ActionController::TestCase
     assert recurring_todo_1.save
 
     # mark next_todo as complete by toggle_check
-    xhr :post, :toggle_check, :id => next_todo.id, :_source_view => 'todo'
+    post :toggle_check, xhr: true, params: { :id => next_todo.id, :_source_view => 'todo' }
     next_todo.reload
     assert next_todo.completed?
 
@@ -889,7 +898,7 @@ class TodosControllerTest < ActionController::TestCase
       assert recurring_todo_1.save
 
       # mark todo_1 as complete by toggle_check
-      xhr :post, :toggle_check, :id => todo_1.id, :_source_view => 'todo'
+      post :toggle_check, xhr: true, params: { :id => todo_1.id, :_source_view => 'todo' }
       todo_1.reload
       assert todo_1.completed?
 
@@ -925,7 +934,7 @@ class TodosControllerTest < ActionController::TestCase
     todo.save!
 
     # When I mark the todo complete
-    xhr :post, :toggle_check, :id => todo.id, :_source_view => 'todo'
+    post :toggle_check, xhr: true, params: { :id => todo.id, :_source_view => 'todo' }
     todo = Todo.find(todo.id) #reload does not seem to work here
     assert todo.completed?
 
@@ -964,7 +973,7 @@ class TodosControllerTest < ActionController::TestCase
     todo.save!
 
     # When I mark the todo complete
-    xhr :post, :toggle_check, :id => todo.id, :_source_view => 'todo'
+    post :toggle_check, xhr: true, params: { :id => todo.id, :_source_view => 'todo' }
     todo.reload
     assert todo.completed?
 
@@ -1011,7 +1020,7 @@ class TodosControllerTest < ActionController::TestCase
     assert_equal 0, successor.predecessors.size
 
     # add predecessor
-    put :add_predecessor, :predecessor=>predecessor.id, :successor=>successor.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>predecessor.id, :successor=>successor.id, :format => "js" }
 
     assert_equal 1, successor.predecessors.count
     assert_equal predecessor.id, successor.predecessors.reload.first.id
@@ -1025,10 +1034,10 @@ class TodosControllerTest < ActionController::TestCase
     other_todo = todos(:phone_grandfather)
 
     # predecessor -> successor
-    put :add_predecessor, :predecessor=>predecessor.id, :successor=>successor.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>predecessor.id, :successor=>successor.id, :format => "js" }
 
     # other_todo -> predecessor -> successor
-    put :add_predecessor, :predecessor=>other_todo.id, :successor=>predecessor.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>other_todo.id, :successor=>predecessor.id, :format => "js" }
 
     assert_equal 1, successor.predecessors(true).count
     assert_equal 0, other_todo.predecessors(true).count
@@ -1047,12 +1056,12 @@ class TodosControllerTest < ActionController::TestCase
     t4 = todos(:construct_dilation_device)
 
     # t1 -> t2
-    put :add_predecessor, :predecessor=>t1.id, :successor=>t2.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>t1.id, :successor=>t2.id, :format => "js" }
     # t3 -> t4
-    put :add_predecessor, :predecessor=>t3.id, :successor=>t4.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>t3.id, :successor=>t4.id, :format => "js" }
 
     # t2 -> t4
-    put :add_predecessor, :predecessor=>t2.id, :successor=>t4.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>t2.id, :successor=>t4.id, :format => "js" }
 
     # should be: t1 -> t2 -> t4 and t3 -> t4
     assert t4.predecessors.map(&:id).include?(t2.id)
@@ -1070,12 +1079,12 @@ class TodosControllerTest < ActionController::TestCase
     t4 = todos(:construct_dilation_device)
 
     # t1 -> t2
-    put :add_predecessor, :predecessor=>t1.id, :successor=>t2.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>t1.id, :successor=>t2.id, :format => "js" }
     # t3 -> t4
-    put :add_predecessor, :predecessor=>t3.id, :successor=>t4.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>t3.id, :successor=>t4.id, :format => "js" }
 
     # t3 -> t2
-    put :add_predecessor, :predecessor=>t3.id, :successor=>t2.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>t3.id, :successor=>t2.id, :format => "js" }
 
     # should be: t1 -> t2 and t3 -> t4 & t2
     assert t3.successors.map(&:id).include?(t4.id)
@@ -1095,12 +1104,12 @@ class TodosControllerTest < ActionController::TestCase
 
     # create same dependency tree as previous test
     # should be: t1 -> t2 -> t4 and t3 -> t4
-    put :add_predecessor, :predecessor=>t1.id, :successor=>t2.id, :format => "js"
-    put :add_predecessor, :predecessor=>t3.id, :successor=>t4.id, :format => "js"
-    put :add_predecessor, :predecessor=>t2.id, :successor=>t4.id, :format => "js"
+    put :add_predecessor, params: { :predecessor=>t1.id, :successor=>t2.id, :format => "js" }
+    put :add_predecessor, params: { :predecessor=>t3.id, :successor=>t4.id, :format => "js" }
+    put :add_predecessor, params: { :predecessor=>t2.id, :successor=>t4.id, :format => "js" }
 
     # removing t4 as successor of t2 should leave t4 blocked with t3 as predecessor
-    put :remove_predecessor, :predecessor=>t2.id, :id=>t4.id, :format => "js"
+    put :remove_predecessor, params: { :predecessor=>t2.id, :id=>t4.id, :format => "js" }
 
     t4.reload
     assert t4.pending?, "t4 should remain pending"
@@ -1115,7 +1124,7 @@ class TodosControllerTest < ActionController::TestCase
     successor.add_predecessor(predecessor)
 
     successor.complete!
-    xhr :post, :toggle_check, :id => predecessor.id, :_source_view => 'todo'
+    post :toggle_check, xhr: true, params: { :id => predecessor.id, :_source_view => 'todo' }
 
     predecessor.reload
     successor.reload
@@ -1134,9 +1143,9 @@ class TodosControllerTest < ActionController::TestCase
 
     params=params.reverse_merge(defaults)
 
-    put :create, _source_view: params[:_source_view],
+    put :create, params: { _source_view: params[:_source_view],
       context_name: params[:context_name], project_name: params[:project_name], tag_list: params[:tag_list],
-      todo: {notes: params[:notes], description: params[:description], due: params[:due], show_from: params[:show_from]}
+      todo: {notes: params[:notes], description: params[:description], due: params[:due], show_from: params[:show_from]} }
   end
 
 end

--- a/test/controllers/todos_controller_test.rb
+++ b/test/controllers/todos_controller_test.rb
@@ -1039,9 +1039,9 @@ class TodosControllerTest < ActionController::TestCase
     # other_todo -> predecessor -> successor
     put :add_predecessor, params: { :predecessor=>other_todo.id, :successor=>predecessor.id, :format => "js" }
 
-    assert_equal 1, successor.predecessors(true).count
-    assert_equal 0, other_todo.predecessors(true).count
-    assert_equal 1, predecessor.predecessors(true).count
+    assert_equal 1, successor.predecessors.reload.count
+    assert_equal 0, other_todo.predecessors.reload.count
+    assert_equal 1, predecessor.predecessors.reload.count
     assert_equal predecessor.id, successor.predecessors.first.id
     assert_equal other_todo.id, predecessor.predecessors.first.id
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -32,7 +32,7 @@ class UsersControllerTest < ActionController::TestCase
   def test_index_pagination_page_2
     User.per_page = 1
     login_as :admin_user
-    get :index, :page => 2
+    get :index, params: { :page => 2 }
     assert_equal assigns['users'],[User.where(:login => 'jane').first]
   end
 
@@ -40,20 +40,20 @@ class UsersControllerTest < ActionController::TestCase
     login_as :admin_user
     @no_users_before = User.count
     user_id = users(:ldap_user).id
-    xhr :post, :destroy, :id => user_id.to_param
+    post :destroy, xhr: true, params: { :id => user_id.to_param }
     assert_equal @no_users_before-1, User.count
   end
 
   def test_update_password_successful
-    get :change_password, :id => users(:admin_user).id 
+    get :change_password, params: { :id => users(:admin_user).id } 
     # should fail because no login
     assert_redirected_to login_path
     login_as :admin_user
     @user = @request.session['user_id']
-    get :change_password, :id => users(:admin_user).id # should now pass because we're logged in
+    get :change_password, params: { :id => users(:admin_user).id } # should now pass because we're logged in
     assert_response :success
     assert_equal assigns['page_title'], "TRACKS::Change password"
-    post :update_password, :id => users(:admin_user).id, :user => {:password => 'newpassword', :password_confirmation => 'newpassword'}
+    post :update_password, params: { :id => users(:admin_user).id, :user => {:password => 'newpassword', :password_confirmation => 'newpassword'} }
     assert_redirected_to preferences_path
     @updated_user = User.find(users(:admin_user).id)
     assert_not_nil User.authenticate(@updated_user.login, 'newpassword')
@@ -61,21 +61,21 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   def test_update_password_no_confirmation
-    post :update_password, :id => users(:admin_user).id, :user => {:password => 'newpassword', :password_confirmation => 'wrong'} 
+    post :update_password, params: { :id => users(:admin_user).id, :user => {:password => 'newpassword', :password_confirmation => 'wrong'} } 
     # should fail because no login
     assert_redirected_to login_path
     login_as :admin_user
-    post :update_password, :id => users(:admin_user).id, :user => {:password => 'newpassword', :password_confirmation => 'wrong'}
+    post :update_password, params: { :id => users(:admin_user).id, :user => {:password => 'newpassword', :password_confirmation => 'wrong'} }
     assert_redirected_to change_password_user_path(users(:admin_user))
     assert_equal 'Validation failed: Password confirmation doesn\'t match confirmation', flash[:error]
   end
 
   def test_update_password_validation_errors
-    post :update_password, :id => users(:admin_user).id
+    post :update_password, params: { :id => users(:admin_user).id }
     # should fail because no login
     assert_redirected_to login_path
     login_as :admin_user
-    post :update_password, :id => users(:admin_user).id, :user => {:password => 'ba', :password_confirmation => 'ba'}
+    post :update_password, params: { :id => users(:admin_user).id, :user => {:password => 'ba', :password_confirmation => 'ba'} }
     assert_redirected_to change_password_user_path(User.find(users(:admin_user).id))
     # For some reason, no errors are being raised now.
     #assert_equal 1, users(:admin_user).errors.count
@@ -96,7 +96,7 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_create_adds_a_new_nonadmin_user
     login_as :admin_user
-    post :create, :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+    post :create, params: { :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     newbie = User.where(:login => 'newbie').first
     assert_equal newbie.login, "newbie"
     assert newbie.is_admin == false || newbie.is_admin == 0
@@ -106,20 +106,20 @@ class UsersControllerTest < ActionController::TestCase
 
   def test_create_redirects_to_home_page
     login_as :admin_user
-    post :create, :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+    post :create, params: { :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     assert_redirected_to root_url
   end
 
   def test_create_sets_flash_message
     login_as :admin_user
-    post :create, :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+    post :create, params: { :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     assert_equal "Signup successful for user newbie.", flash[:notice], "expected flash notice not found"
   end
 
   def test_create_adds_a_user
     login_as :admin_user
     assert_difference 'User.count' do
-      post :create, :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+      post :create, params: { :user => {:login => 'newbie', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     end
   end
 
@@ -128,7 +128,7 @@ class UsersControllerTest < ActionController::TestCase
   def test_create_by_non_admin
     login_as :other_user
     assert_no_difference 'User.count' do
-      post :create, :user => {:login => 'newbie2', :password => 'newbiepass2', :password_confirmation => 'newbiepass2'}
+      post :create, params: { :user => {:login => 'newbie2', :password => 'newbiepass2', :password_confirmation => 'newbiepass2'} }
     end
     assert_response :success
     assert_template 'users/nosignup'
@@ -141,38 +141,38 @@ class UsersControllerTest < ActionController::TestCase
   def test_create_with_invalid_password_does_not_add_a_new_user
     login_as :admin_user
     assert_no_difference 'User.count' do
-      post :create, :user => {:login => 'newbie', :password => '', :password_confirmation => ''}
+      post :create, params: { :user => {:login => 'newbie', :password => '', :password_confirmation => ''} }
     end
   end
 
   def test_create_with_invalid_password_redirects_to_new_user_page
     login_as :admin_user
-    post :create, :user => {:login => 'newbie', :password => '', :password_confirmation => ''}
+    post :create, params: { :user => {:login => 'newbie', :password => '', :password_confirmation => ''} }
     assert_redirected_to signup_path
   end
 
   def test_create_with_invalid_login_does_not_add_a_new_user
     login_as :admin_user
-    post :create, :user => {:login => 'n', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+    post :create, params: { :user => {:login => 'n', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     assert_redirected_to signup_path
   end
 
   def test_create_with_invalid_login_redirects_to_new_user_page
     login_as :admin_user
-    post :create, :user => {:login => 'n', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+    post :create, params: { :user => {:login => 'n', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     assert_redirected_to signup_path
   end
 
   def test_create_with_duplicate_login_does_not_add_a_new_user
     login_as :admin_user
     assert_no_difference 'User.count' do
-      post :create, :user => {:login => 'jane', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+      post :create, params: { :user => {:login => 'jane', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     end
   end
 
   def test_create_with_duplicate_login_redirects_to_new_user_page
     login_as :admin_user
-    post :create, :user => {:login => 'jane', :password => 'newbiepass', :password_confirmation => 'newbiepass'}
+    post :create, params: { :user => {:login => 'jane', :password => 'newbiepass', :password_confirmation => 'newbiepass'} }
     assert_redirected_to signup_path
   end
 

--- a/test/integration/recurring_todos_test.rb
+++ b/test/integration/recurring_todos_test.rb
@@ -4,9 +4,9 @@ class RecurringTodosTest < ActionDispatch::IntegrationTest
 
   def logs_in_as(user,plain_pass)
     @user = user
-    post "/login", :user_login => @user.login,
+    post "/login", params: { :user_login => @user.login,
       :user_password => plain_pass,
-      :user_noexpiry => 'n'
+      :user_noexpiry => 'n' }
     assert_response :redirect
     follow_redirect!
     assert_response :success
@@ -22,7 +22,7 @@ class RecurringTodosTest < ActionDispatch::IntegrationTest
 
     # when I toggle the todo complete
     todo = Todo.where(:recurring_todo_id => 1).first
-    put "/todos/#{todo.id}/toggle_check", :_source_view => 'todo'
+    put "/todos/#{todo.id}/toggle_check", params: { :_source_view => 'todo' }
     todo.reload
     assert todo.completed?
 
@@ -32,7 +32,8 @@ class RecurringTodosTest < ActionDispatch::IntegrationTest
     refute_equal todo2.id, todo.id # and the todos should be different
 
     # when I delete the recurring todo
-    delete_via_redirect "/recurring_todos/#{rt.id}", :_source_view => 'todo'
+    delete "/recurring_todos/#{rt.id}", params: { :_source_view => 'todo' }
+    follow_redirect!
 
     todo.reload
     todo2.reload

--- a/test/integration/stories_test.rb
+++ b/test/integration/stories_test.rb
@@ -29,9 +29,9 @@ class StoriesTest < ActionDispatch::IntegrationTest
       get "/signup"
       assert_response :success
       assert_template "users/new"
-      post "/users", :user => {:login => "newbie",
-                                    :password => "newbiepass",
-                                    :password_confirmation => "newbiepass"}
+      post "/users", params: { :user => {:login => "newbie",
+                                         :password => "newbiepass",
+                                         :password_confirmation => "newbiepass"} }
       assert_response :redirect
       follow_redirect!
       assert_response :success
@@ -47,9 +47,9 @@ class StoriesTest < ActionDispatch::IntegrationTest
 
       def logs_in_as(user,plain_pass)
         @user = user
-        post "/login", :user_login => @user.login,
-                      :user_password => plain_pass,
-                      :user_noexpiry => 'n'
+        post "/login", params: { :user_login => @user.login,
+                                 :user_password => plain_pass,
+                                 :user_noexpiry => 'n' }
         assert_response :redirect
         follow_redirect!
         assert_response :success
@@ -75,7 +75,7 @@ class StoriesTest < ActionDispatch::IntegrationTest
       end
 
       def signs_up_with(options)
-        post "/users", options
+        post "/users", params: options
         assert_response :redirect
         follow_redirect!
         assert_response :success

--- a/test/integration/todo_xml_api_test.rb
+++ b/test/integration/todo_xml_api_test.rb
@@ -14,10 +14,10 @@ class TodoXmlApiTest < ActionDispatch::IntegrationTest
   end
 
   def test_get_tickler_needs_authentication
-    get '/tickler.xml', {}, {}
+    get '/tickler.xml', params: {}, headers: {}
     assert_response 401
 
-    get "/tickler.xml", {}, {'HTTP_AUTHORIZATION' => "Basic " + Base64.encode64("wrong:wrong"),'ACCEPT' => 'application/xml'}
+    get "/tickler.xml", params: {}, headers: {'HTTP_AUTHORIZATION' => "Basic " + Base64.encode64("wrong:wrong"),'ACCEPT' => 'application/xml'}
     assert_response 401
   end
 

--- a/test/integration/users_xml_api_test.rb
+++ b/test/integration/users_xml_api_test.rb
@@ -67,7 +67,7 @@ class UsersXmlApiTest < ActionDispatch::IntegrationTest
   end
   
   def test_get_users_as_xml
-    get '/users.xml', {}, basic_auth_headers()
+    get '/users.xml', params: {}, headers: basic_auth_headers()
     assert_response :success
     assert_select 'users' do
       assert_select 'user', count: 4
@@ -76,7 +76,7 @@ class UsersXmlApiTest < ActionDispatch::IntegrationTest
   end
 
   def test_get_user_as_xml
-    get "/users/#{users(:other_user).id}.xml", {}, basic_auth_headers()
+    get "/users/#{users(:other_user).id}.xml", params: {}, headers: basic_auth_headers()
     assert_response :success
     assert_select 'user'
     assert_select 'password', false

--- a/test/models/todo_create_params_helper_test.rb
+++ b/test/models/todo_create_params_helper_test.rb
@@ -6,13 +6,13 @@ class TodoCreateParamsHelperTest < ActiveSupport::TestCase
   def test_works_with_request_as_root_hash_entry
     params =  ActionController::Parameters.new({'request' => { 'todo' => { 'description' => 'foo'}}})
     params_helper = Todos::TodoCreateParamsHelper.new(params, users(:admin_user))
-    assert_equal({'description' => 'foo'}, params_helper.attributes)
+    assert_equal({'description' => 'foo'}, params_helper.attributes.to_h)
   end
 
   def test_works_with_todo_as_root_hash_entry
     params = ActionController::Parameters.new({ 'todo' => { 'description' => 'foo'}})
     params_helper = Todos::TodoCreateParamsHelper.new(params, users(:admin_user))
-    assert_equal({'description' => 'foo'}, params_helper.attributes)
+    assert_equal({'description' => 'foo'}, params_helper.attributes.to_h)
   end
 
   def test_show_from_accessor

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,7 +69,7 @@ class ActionController::TestCase
   end
 
   def ajax_create(name)
-    xhr :post, :create, get_model_class.downcase => {:name => name}
+    post :create, xhr: true, params: { get_model_class.downcase => {:name => name} }
   end
 
   def assert_number_of_items_in_rss_feed(expected)
@@ -110,7 +110,7 @@ end
 class ActionDispatch::IntegrationTest
 
   def authenticated_post_xml(url, username, password, parameters, headers = {})
-    post url, parameters,
+    post url, params: parameters, headers:
         { 'HTTP_AUTHORIZATION' => "Basic " + Base64.encode64("#{username}:#{password}"),
           'ACCEPT' => 'application/xml',
           'CONTENT_TYPE' => 'application/xml'
@@ -118,7 +118,7 @@ class ActionDispatch::IntegrationTest
   end
 
   def authenticated_get_xml(url, username, password, parameters, headers = {})
-    get url, parameters,
+    get url, params: parameters, headers:
         { 'HTTP_AUTHORIZATION' => "Basic " + Base64.encode64("#{username}:#{password}"),
           'ACCEPT' => 'application/xml',
           'CONTENT_TYPE' => 'application/xml'


### PR DESCRIPTION
This is part one of the prepwork for Rails 5.1 by removing all the deprecation warnings the test suite screams at us when the tests are running.

Huge shoutout to @dnrce for doing all of this in #2084. This is the last PR from that monster of a PR to split out.

Closes #2084