### PR TITLE
Convert to ApplicationRecord

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,4 +1,4 @@
-class Attachment < ActiveRecord::Base
+class Attachment < ApplicationRecord
   belongs_to :todo, touch: true
 
   has_attached_file :file,

--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -1,4 +1,4 @@
-class Context < ActiveRecord::Base
+class Context < ApplicationRecord
 
   has_many :todos, -> { order("todos.due IS NULL, todos.due ASC, todos.created_at ASC").includes(:project) }, :dependent => :delete_all
   has_many :recurring_todos, :dependent => :delete_all

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -1,4 +1,4 @@
-class Dependency < ActiveRecord::Base
+class Dependency < ApplicationRecord
 
   # touch to make sure todo caches for predecessor and successor are invalidated
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,4 @@
-class Note < ActiveRecord::Base
+class Note < ApplicationRecord
   belongs_to :user
   belongs_to :project
 

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,4 +1,4 @@
-class Preference < ActiveRecord::Base
+class Preference < ApplicationRecord
   belongs_to :user
   belongs_to :sms_context, :class_name => 'Context'
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,4 @@
-class Project < ActiveRecord::Base
+class Project < ApplicationRecord
   has_many :todos, -> {order("todos.due IS NULL, todos.due ASC, todos.created_at ASC")}, dependent: :delete_all
   has_many :notes, -> {order "created_at DESC"}, dependent: :delete_all
   has_many :recurring_todos

--- a/app/models/recurring_todo.rb
+++ b/app/models/recurring_todo.rb
@@ -1,4 +1,4 @@
-class RecurringTodo < ActiveRecord::Base
+class RecurringTodo < ApplicationRecord
   belongs_to :context
   belongs_to :project
   belongs_to :user

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ActiveRecord::Base
+class Tag < ApplicationRecord
 
   has_many :taggings
   has_many :taggable, :through => :taggings

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,7 +1,7 @@
 
 # The Tagging join model.
 
-class Tagging < ActiveRecord::Base
+class Tagging < ApplicationRecord
 
   belongs_to :tag
   belongs_to :taggable, :polymorphic => true, :touch => true

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,4 +1,4 @@
-class Todo < ActiveRecord::Base
+class Todo < ApplicationRecord
 
   MAX_DESCRIPTION_LENGTH = 300
   MAX_NOTES_LENGTH = 60000

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 require 'digest/sha1'
 require 'bcrypt'
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   # Virtual attribute for the unencrypted password
   attr_accessor :password
 


### PR DESCRIPTION
Rails 5 requires the use of this superclass for all database backed model objects now.

I, uh, forgot this before. :disappointed: