### PR TITLE
Fix the undefined reference to Staleness

### DIFF
--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -1,3 +1,5 @@
+require 'staleness'
+
 module TodosHelper
 
   # === helpers for rendering container

--- a/lib/staleness.rb
+++ b/lib/staleness.rb
@@ -1,4 +1,5 @@
 require 'active_support/all'
+require 'user_time'
 
 class Staleness
   SECONDS_PER_DAY = 86400


### PR DESCRIPTION
Not sure what's going on with Rails' autoloading here, so fix it the ruby way by using plain ol' `require`

Closes #2137