### PR TITLE
Remove rack-dev-mark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ group :development do
 
   gem "bullet"
   gem "rack-mini-profiler"
-  gem "rack-dev-mark"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,8 +151,6 @@ GEM
     powerpack (0.1.2)
     puma (3.12.0)
     rack (2.0.6)
-    rack-dev-mark (0.7.7)
-      rack (>= 1.1, < 2.1)
     rack-mini-profiler (1.0.0)
       rack (>= 1.2.0)
     rack-test (1.1.0)
@@ -298,7 +296,6 @@ DEPENDENCIES
   mysql2 (~> 0.4.0)
   paperclip
   puma (~> 3.0)
-  rack-dev-mark
   rack-mini-profiler
   rails (~> 5.2.1)
   rails-controller-testing


### PR DESCRIPTION
I dislike the way this gem covers up important parts of the UI.