### PR TITLE
Bump Ruby to 2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.4
 
 WORKDIR /app
 


### PR DESCRIPTION
Ruby 2.3 has reached end of life and is no longer maintained. Bump to
using Ruby 2.4 so that we remain on a supported Ruby version.