### PR TITLE
#2036: Change empty XML responses to have the correct base element

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -20,7 +20,7 @@ class CalendarController < ApplicationController
         render :action => 'show', :layout => false, :content_type => Mime[:ics]
       }
       format.xml {
-        render :xml => @due_all.to_xml( *todo_xml_params )
+        render :xml => @due_all.to_xml( *[todo_xml_params[0].merge({:root => :todos})] )
       }
     end
   end

--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -20,7 +20,7 @@ class ContextsController < ApplicationController
     respond_to do |format|
       format.html &render_contexts_html
       format.m    &render_contexts_mobile
-      format.xml  { render :xml => @all_contexts.to_xml( :except => :user_id ) }
+      format.xml  { render :xml => @all_contexts.to_xml(:root => :contexts, :except => :user_id) }
       format.any(:rss, :atom) do
         @feed_title = 'Tracks Contexts'
         @feed_description = "Lists all the contexts for #{current_user.display_name}"
@@ -57,7 +57,7 @@ class ContextsController < ApplicationController
       respond_to do |format|
         format.html
         format.m    &render_context_mobile
-        format.xml  { render :xml => @context.to_xml( :except => :user_id ) }
+        format.xml  { render :xml => @context.to_xml(:root => :context, :except => :user_id) }
       end
     else
       respond_to do |format|

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -9,7 +9,7 @@ class NotesController < ApplicationController
     @source_view = 'note_list'
     respond_to do |format|
       format.html
-      format.xml { render :xml => @all_notes.to_xml( :except => :user_id )  }
+      format.xml { render :xml => @all_notes.to_xml(:root => :notes, :except => :user_id )  }
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,7 +37,7 @@ class ProjectsController < ApplicationController
           @down_count = @active_projects.size + @hidden_projects.size + @completed_projects.size
           cookies[:mobile_url]= {:value => request.fullpath, :secure => SITE_CONFIG['secure_cookies']}
         end
-        format.xml   { render :xml => @projects.to_xml( :except => :user_id )  }
+        format.xml { render :xml => @projects.to_xml(:root => :projects, :except => :user_id) }
         format.any(:rss, :atom) do
           @feed_title = I18n.t('models.project.feed_title')
           @feed_description = I18n.t('models.project.feed_description', :username => current_user.display_name)
@@ -158,7 +158,7 @@ class ProjectsController < ApplicationController
         @mobile_from_project = @project.id
       end
       format.xml   do
-        render :xml => @project.to_xml(:except => :user_id) { |xml|
+        render :xml => @project.to_xml(:root => :project, :except => :user_id) { |xml|
           xml.not_done { @not_done_todos.each { |child| child.to_xml(:builder => xml, :skip_instruct => true) } }
           xml.deferred { @deferred_todos.each { |child| child.to_xml(:builder => xml, :skip_instruct => true) } }
           xml.pending { @pending_todos.each { |child| child.to_xml(:builder => xml, :skip_instruct => true) } }

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -49,7 +49,7 @@ class TodosController < ApplicationController
       end
       format.xml do
         @xml_todos = params[:limit_to_active_todos] ? @not_done_todos : @todos
-        render :xml => @xml_todos.to_xml( *todo_xml_params )
+        render :xml => @xml_todos.to_xml( *[todo_xml_params[0].merge({:root => :todos})] )
       end
       format.any(:rss, :atom) do
         @feed_title = 'Tracks Actions'.freeze
@@ -251,7 +251,7 @@ class TodosController < ApplicationController
     @todo = current_user.todos.find(params['id'])
     respond_to do |format|
       format.m { render :action => 'show' }
-      format.xml { render :xml => @todo.to_xml( *todo_xml_params ) }
+      format.xml { render :xml => @todo.to_xml( *[todo_xml_params[0].merge({:root => :todo})] ) }
     end
   end
 
@@ -560,7 +560,7 @@ class TodosController < ApplicationController
       format.html
       format.xml do
         completed_todos = current_user.todos.completed
-        render :xml => completed_todos.to_xml( *todo_xml_params )
+        render :xml => completed_todos.to_xml( *[todo_xml_params[0].merge({:root => :todos})] )
       end
     end
   end
@@ -593,7 +593,7 @@ class TodosController < ApplicationController
         init_data_for_sidebar unless mobile?
       end
       format.m
-      format.xml { render :xml => @not_done_todos.to_xml( *todo_xml_params ) }
+      format.xml { render :xml => @not_done_todos.to_xml( *[todo_xml_params[0].merge({:root => :todos})] ) }
     end
   end
 
@@ -759,7 +759,7 @@ class TodosController < ApplicationController
     @hidden = current_user.todos.hidden
     respond_to do |format|
       format.xml {
-        render :xml => @hidden.to_xml( *todo_xml_params )
+        render :xml => @hidden.to_xml( *[todo_xml_params[0].merge({:root => :todos})] )
       }
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
       end
       format.xml do
         @users  = User.order('login')
-        render :xml => @users.to_xml(:except => [ :password ])
+        render :xml => @users.to_xml(:root => :users, :except => [ :password ])
       end
     end
   end
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
   # GET /users/id GET /users/id.xml
   def show
     @user = User.find(params[:id])
-    render :xml => @user.to_xml(:except => [ :password ])
+    render :xml => @user.to_xml(:root => :user, :except => [ :password ])
   end
 
   # GET /users/new


### PR DESCRIPTION
Adding the :root option to those XML APIs that return a response when no items are found. The ones returning only a single item should return an error response if the requested item was found, and therefore forcing the root element shouldn't be necessary there.