### PR TITLE
Remove the autofocus from the search fields

### DIFF
--- a/app/views/search/_index.html.erb
+++ b/app/views/search/_index.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid">
 <%= form_tag(search_results_path, class: 'navbar-form') do %>
   <div class="input-group">
-    <%= text_field_tag(:search, params[:search], class: 'form-control', autofocus: true) %>
+    <%= text_field_tag(:search, params[:search], class: 'form-control') %>
     <div class="input-group-btn">
       <%= button_tag(type: 'submit', class: 'btn pull-right') do%>
         <%= icon('search', class: 'hidden-xs') %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -5,7 +5,7 @@
       <%= form_tag(search_results_path) do %>
         <div class="form-group">
           <%= label_tag 'Search', nil, class: 'sr-only' %>
-          <%= text_field_tag(:search, params[:search], class: 'form-control', autofocus: true) %>
+          <%= text_field_tag(:search, params[:search], class: 'form-control') %>
         </div>
         <%= submit_tag t('common.search'), class: 'btn btn-primary pull-right' %>
       <% end %>

--- a/app/views/todos/_new_todo_form.html.erb
+++ b/app/views/todos/_new_todo_form.html.erb
@@ -12,7 +12,7 @@
 
     <label for="todo_description" style="float:left"><%= Todo.human_attribute_name('description') %></label>
     <a href="#" id="new_todo_starred_link" class="undecorated_link" ><%= image_tag("blank.png", :title =>t('todos.star_action'), :class => "todo_star", :style=> "float: right")%></a>
-    <%= t.text_field("description", "size" => 30, "maxlength" => 100, "autocomplete" => "off", :autofocus => 1) %>
+    <%= t.text_field("description", "size" => 30, "maxlength" => 100, "autocomplete" => "off", :autofocus => true) %>
 
     <label for="todo_notes"><%= Todo.human_attribute_name('notes') %></label>
     <%= t.text_area("notes", "cols" => 29, "rows" => 6) %>


### PR DESCRIPTION
This should set the autofocus to the new todo entry form (which already
was set for autofocus) rather than the search box

Fixes #2156
Related to #1139