### PR TITLE
#2034: Change the REST API documentation to point to the existing don…

### DIFF
--- a/app/views/integrations/rest_api.html.erb
+++ b/app/views/integrations/rest_api.html.erb
@@ -55,9 +55,9 @@
 
 <ul>
   <li>/todos.xml</li>
+  <li>/todos/done.xml</li>
   <li>/todos/<code>ID</code>.xml</li>
   <li>/tickler.xml</li>
-  <li>/done.xml</li>
   <li>/hidden.xml</li>
   <li>/calendar.xml</li>
   <li>/contexts.xml</li>


### PR DESCRIPTION
…e tasks API

Fix the done.xml URL in the REST API documentation. It seems that the URL hasn't been valid as a done tasks XML API URL for quite some time, so I figure no-one should be relying on the documented URL working.