### PR TITLE
#2203: Try to use basic password also as a token when accessing a tok…

### DIFF
--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -72,7 +72,14 @@ module LoginSystem
 
   def login_or_feed_token_required
     if ['rss', 'atom', 'txt', 'ics', 'xml'].include?(params[:format])
+      # Login based on the token GET parameter
       if user = User.where(:token => params[:token]).first
+        set_current_user(user)
+        return true
+      end
+      # Allow also login based on auth data
+      auth = get_basic_auth_data
+      if user = User.where(:login => auth[:user], :token => auth[:pass]).first
         set_current_user(user)
         return true
       end


### PR DESCRIPTION
…en-enabled endpoint

I realised that adding the token GET parameter support alone wouldn't help with the token working in my application, and as @mattr- mentioned moving to basic auth with tokens also I decided to give it a try.

This changes the login function to use the basic authentication credentials as username + token when accessing a token-enabled endpoint, which means that both the token GET parameter and the basic auth work. Additionally, as before, username and password can also be used with the basic auth.