### PR TITLE
Upgrade sanitize.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "sqlite3", group: :sqlite
 gem "mysql2", "~> 0.5.2", group: :mysql
 
 gem "RedCloth"
-gem "sanitize", ">=3.0.0"
+gem "sanitize", "~> 5.0"
 gem "will_paginate"
 gem "acts_as_list"
 gem "aasm", '~> 3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,8 +134,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
-    nokogumbo (1.5.0)
-      nokogiri
+    nokogumbo (2.0.1)
+      nokogiri (~> 1.8, >= 1.8.4)
     paperclip (6.1.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -206,10 +206,10 @@ GEM
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
-    sanitize (4.6.6)
+    sanitize (5.0.0)
       crass (~> 1.0.2)
-      nokogiri (>= 1.4.4)
-      nokogumbo (~> 1.4)
+      nokogiri (>= 1.8.0)
+      nokogumbo (~> 2.0)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -305,7 +305,7 @@ DEPENDENCIES
   rails_autolink
   rspec-expectations
   rubocop (~> 0.65)
-  sanitize (>= 3.0.0)
+  sanitize (~> 5.0)
   sass-rails (~> 5.0)
   selenium-webdriver (~> 2.53)
   simplecov

--- a/app/helpers/rendering_helper.rb
+++ b/app/helpers/rendering_helper.rb
@@ -13,7 +13,7 @@ module RenderingHelper
         # do not change string; URL is already linked
         href
       else
-        content_tag(:a, h(href), :href => h(href))
+        content_tag(:a, h(href), :href => URI.escape(href))
       end
     end
   end

--- a/test/helpers/rendering_helper_test.rb
+++ b/test/helpers/rendering_helper_test.rb
@@ -28,12 +28,13 @@ class RenderingHelperTest < ActionView::TestCase
   end
 
   test "message link" do
+    expected = '<p>Call <a href="message://%3C123%3E">message://&lt;123&gt;</a>.</p>'
     actual = render_text("Call message://<123>.")
-    assert_equal('<p>Call <a href="message://&lt;123&gt;">message://&lt;123&gt;</a>.</p>', actual)
+    assert_equal(expected, actual)
   end
 
   test "tagged message link" do
-    expected = '<p>This message is already tagged: <a href="message://&lt;12345&gt;">Call bob</a>.</p>'
+    expected = '<p>This message is already tagged: <a href="message://%3C12345%3E">Call bob</a>.</p>'
     actual = render_text(expected)
     assert_equal(expected, actual)
   end


### PR DESCRIPTION
Upgrade sanitize. Replaces #2125.

Fixes the incorrect test that the `sanitize` upgrade exposed.