### PR TITLE
Single quotes don't need to be escaped here.

### DIFF
--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -770,11 +770,11 @@ cs:
     edit_recurring_todo: Upravit opakovaný úkol
     error_completing_todo: Nepodařilo se ukončit / aktivovat opakovaný úkol %{description}
     error_deleting_item: Nepodařilo se smazat položku %{description}
-    error_deleting_recurring: Nepodařilo se smazat opakovaný úkol \'%{description}\'
+    error_deleting_recurring: Nepodařilo se smazat opakovaný úkol '%{description}'
     error_removing_dependency: Nepodařilo se odstranit závislost
-    error_saving_recurring: Nepodařilo se uložit opakovaný úkol \'%{description}\'
+    error_saving_recurring: Nepodařilo se uložit opakovaný úkol '%{description}'
     error_starring: Nepodařilo se označit úkol hvězdičkou '%{description}'
-    error_starring_recurring: Nebylo možno ohvězdičkovat opakovaný úkol \'%{description}\'
+    error_starring_recurring: Nebylo možno ohvězdičkovat opakovaný úkol '%{description}'
     error_toggle_complete: Nepodařilo se označit úkol jako hotový
     feeds:
       completed: 'Hotové: %{date}'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -791,9 +791,9 @@ de:
     error_removing_dependency: Beim Entfernen der Abhängigkeit ist ein Fehler aufgetreten
     error_saving_recurring: Es gab einen Fehler beim Speichern der wiederkehrenden
       Aufgabe '%{description}'
-    error_starring: Konnte die Hervorhebung von \'%{description}\' nicht durchführen
+    error_starring: Konnte die Hervorhebung von '%{description}' nicht durchführen
     error_starring_recurring: Konnte die Hervorhebung der wiederkehrenden Aufgabe
-      \'%{description}\' nicht durchführen
+      '%{description}' nicht durchführen
     error_toggle_complete: Könnte nicht diese Marke todo komplett
     feeds:
       completed: 'Erledigt: %{date}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -482,7 +482,7 @@ en:
     completed_rest_of_week: Completed in the rest of this week
     completed_rest_of_month: Completed in the rest of this month
     show_from: Show from
-    error_starring_recurring: "Could not toggle the star of recurring todo \'%{description}\'"
+    error_starring_recurring: "Could not toggle the star of recurring todo '%{description}'"
     recurring_action_deleted: Action was deleted. Because this action is recurring, a new action was added
     completed_recurring: Completed recurring todos
     added_new_next_action: Added new next action
@@ -535,7 +535,7 @@ en:
     completed_last_day: Completed in the last 24 hours
     show_in_days: Show in %{days} days
     no_project: --No project--
-    error_saving_recurring: "There was an error saving the recurring todo \'%{description}\'"
+    error_saving_recurring: "There was an error saving the recurring todo '%{description}'"
     new_related_todo_created_short: created a new todo
     all_completed: All completed actions
     feed_title_in_context: "in context '%{context}'"
@@ -582,7 +582,7 @@ en:
       one: Has one pending action
       other: Has %{count} pending actions
     delete_action: Delete action
-    error_deleting_recurring: "There was an error deleting the recurring todo \'%{description}\'"
+    error_deleting_recurring: "There was an error deleting the recurring todo '%{description}'"
     recurring_todos: Recurring todos
     delete: Delete
     cannot_add_dependency_to_completed_todo: Cannot add this action as a dependency to a completed action!

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -696,7 +696,7 @@ es:
       stats: "%a %d-%m"
     pm: pm
   todos:
-    action_deferred: La acción \'%{description}\' se aplazó
+    action_deferred: La acción '%{description}' se aplazó
     action_deleted_error: Failed to delete the action
     action_deleted_success: Successfully deleted next action
     action_due_on: "(action due on %{date})"
@@ -777,11 +777,11 @@ es:
     error_completing_todo: There was an error completing / activating the recurring
       todo %{description}
     error_deleting_item: There was an error deleting the item %{description}
-    error_deleting_recurring: There was an error deleting the recurring todo \'%{description}\'
+    error_deleting_recurring: There was an error deleting the recurring todo '%{description}'
     error_removing_dependency: There was an error removing the dependency
-    error_saving_recurring: There was an error saving the recurring todo \'%{description}\'
-    error_starring: Could not toggle the star of this todo \'%{description}\'
-    error_starring_recurring: Could not toggle the star of recurring todo \'%{description}\'
+    error_saving_recurring: There was an error saving the recurring todo '%{description}'
+    error_starring: Could not toggle the star of this todo '%{description}'
+    error_starring_recurring: Could not toggle the star of recurring todo '%{description}'
     error_toggle_complete: Could not mark this todo complete
     feed_title_in_context: in context '%{context}'
     feed_title_in_project: in project '%{project}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -821,14 +821,14 @@ fr:
     error_deleting_item: Il s'est produit une erreur lors de la suppression de l'élément
       %{description}
     error_deleting_recurring: Il s'est produit une erreur lors de la suppression de
-      la tâche récurrente \'%{description}\'
+      la tâche récurrente '%{description}'
     error_removing_dependency: Il s'est produit une erreur lors de la suppression
       de la dépendance
     error_saving_recurring: Il s'est produit une erreur lors de la sauvegarde de la
-      tâche récurrente \'%{description}\'
-    error_starring: Impossible d'actionner l'étoile de cette tache \'%{description}\'
+      tâche récurrente '%{description}'
+    error_starring: Impossible d'actionner l'étoile de cette tache '%{description}'
     error_starring_recurring: Impossible d'actionner l'étoile de la tache récurrente
-      \'%{description}\'
+      '%{description}'
     error_toggle_complete: Impossible de marquer cette tache comme complétée
     feeds:
       completed: 'Complété : %{date}'
@@ -839,7 +839,7 @@ fr:
       one: A une action en attente
       other: A %{count} actions en attente
     hidden_actions: Actions cachées
-    in_hidden_state: a l\'état caché
+    in_hidden_state: a l'état caché
     in_pending_state: en attente
     list_incomplete_next_actions: Liste les prochaines actions incomplètes
     list_incomplete_next_actions_with_limit: Liste les %{count} dernières actions

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -898,14 +898,14 @@ nl:
     error_deleting_item: Er is een fout opgetreden bij het verwijderen van het item
       '%{description}'
     error_deleting_recurring: Er is een fout opgetreden bij het verwijderen van het
-      item \'%{description}\'
+      item '%{description}'
     error_removing_dependency: Er is een fout opgetreden het verwijderen van de afhankelijke
       actie
     error_saving_recurring: Er is een fout opgetreden het opslaan van de terugkerende
       actie '%{description}'
-    error_starring: Kon niet de ster van deze actie niet omzetten \'%{description}\'
+    error_starring: Kon niet de ster van deze actie niet omzetten '%{description}'
     error_starring_recurring: Kon niet de ster van deze terugkerende actie niet omzetten
-      \'%{description}\'
+      '%{description}'
     error_toggle_complete: Kon deze actie niet als afgerond markeren
     feeds:
       completed: 'Voltooid: %{date}'


### PR DESCRIPTION
This was preventing the app from loading, weirdly.

The error I was getting (in all places where I've made changes) looked like this: ```
I18n::InvalidLocaleData: can not load translations from /Users/srbaker/Projects/TracksApp/tracks/config/locales/en.yml: #<Psych::SyntaxError: (/Users/srbaker/Projects/TracksApp/tracks/config/locales/en.yml): found unknown escape character while parsing a quoted scalar at line 585 column 31>```

I don't know why I'm getting this and others aren't: I suspect I'm on a newer `libyaml` that is more strict.

I've confirmed this with the YAML 1.2 spec, and a few other projects around the web, such as: https://github.com/stympy/faker/pull/1305