### PR TITLE
#2295: Fix for the migration bug in MySQL

### DIFF
--- a/db/migrate/20190618202817_add_user_id_to_tag.rb
+++ b/db/migrate/20190618202817_add_user_id_to_tag.rb
@@ -4,7 +4,7 @@ class AddUserIdToTag < ActiveRecord::Migration[5.2]
 
     # Find uses of each tag for both Todos and RecurringTodos to
     # figure out which users use which tags.
-    @tags = execute <<-EOQ
+    @tags = exec_query <<-EOQ
       SELECT t.id AS tid, tds.user_id AS todo_uid, rt.user_id AS rtodo_uid
       FROM tags t
       JOIN taggings tgs ON tgs.tag_id = t.id


### PR DESCRIPTION
This fixes the tag migration at least in my MySQL environment. exec_query apparently returns the results in constant formats while execute doesn't:

* https://stackoverflow.com/questions/14824453/rails-raw-sql-example#comment82683569_14840547
* https://api.rubyonrails.org/classes/ActiveRecord/Result.html

I tested the change on MySQL, SQlite and PostgreSQL in my own environment.