### PR TITLE
Version 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * IRC channel: #tracks on Freenode
 * Original developer: bsag (http://www.rousette.org.uk/)
 * Contributors: https://github.com/TracksApp/tracks/wiki/Contributors
-* Version: 2.4.0
+* Version: 2.4.1
 
 [![Build Status](https://github.com/TracksApp/tracks/workflows/Continuous%20Integration/badge.svg)](https://github.com/TracksApp/tracks/actions)
 [![Code Climate](https://codeclimate.com/github/TracksApp/tracks/badges/gpa.svg)](https://codeclimate.com/github/TracksApp/tracks)

--- a/config/initializers/tracks.rb
+++ b/config/initializers/tracks.rb
@@ -1,4 +1,4 @@
-tracks_version='2.4.0'
+tracks_version='2.4.1'
 # comment out next two lines if you do not want (or can not) the date of the
 # last git commit in the footer
 info=`git log --pretty=format:"%ai" -1`

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Version 2.4.1
+
+### Bug fixes
+* Fixed a bug in the tag migration that prevented the migration from completing
+  at least in some MySQL environments. The bug only affected upgrading an existing Tracks
+  installation.
+
 ## Version 2.4.0
 
 ### New features

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -10,7 +10,7 @@ For alternative installation options and tips for specific environments, please 
 
 Tracks has a few software requirements that must be satisfied before installation:
 
-1. **Ruby**. Tracks requires Ruby 1.9.3 or greater.
+1. **Ruby**. Tracks requires Ruby 2.4 or greater.
 2. **Bundler**. Tracks requires a recent version of [Bundler](http://bundler.io) to handle the installation of dependencies. Bundler is typically installed by running `gem install bundler`.
 3. **Database**. Tracks is tested on [MySQL](http://www.mysql.com/) and [SQLite](http://www.sqlite.org/), but [PostgreSQL](http://www.postgresql.org/) can also be used. Of the three, SQLite requires the least configuration. Whatever your choice, the appropriate database software must be installed.
 

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -1,6 +1,6 @@
 # Upgrading Tracks
 
-## Upgrading from Tracks 2.3 to 2.4.0
+## Upgrading from Tracks 2.3 to 2.4.1
 
 These upgrade instructions are rough. Please suggest improvements in a GitHub issue if you run into problems.
 


### PR DESCRIPTION
I suggest we publish a new version 2.4.1 right away to avoid any users getting hit by the migration bug.