### PR TITLE
#2220: Use @original_item over other @original_item like instance variables

### DIFF
--- a/app/helpers/todos_helper.rb
+++ b/app/helpers/todos_helper.rb
@@ -501,7 +501,13 @@ module TodosHelper
         @todo_was_deferred_from_active_state                                              ||
         @tag_was_removed                                                                  ||
         @todo_was_destroyed                                                               ||
-        (@todo.completed? && !(@original_item_was_deferred || @original_item_was_hidden || @original_item_was_pending))
+        (
+          @todo.completed? && !(
+            @original_item.deferred? ||
+            @original_item.hidden? ||
+            @original_item.pending?
+          )
+        )
       )
     end
 
@@ -662,9 +668,9 @@ module TodosHelper
       page.calendar { container_id = "#{@original_item_due_id}_container-empty-d" if @old_due_empty }
       page.tag      {
         container_id = "hidden_container-empty-d" if (@remaining_hidden_count == 0 && !@todo.hidden? && @todo_hidden_state_changed) ||
-          (@remaining_hidden_count == 0 && @todo.completed? && @original_item_was_hidden)
+          (@remaining_hidden_count == 0 && @todo.completed? && @original_item.hidden?)
         container_id = "deferred_pending_container-empty-d" if (todo_was_removed_from_deferred_or_blocked_container && @remaining_deferred_or_pending_count == 0) ||
-          (@original_item_was_deferred && @remaining_deferred_or_pending_count == 0 && (@todo.completed? || @tag_was_removed))
+          (@original_item.deferred? && @remaining_deferred_or_pending_count == 0 && (@todo.completed? || @tag_was_removed))
         container_id = "completed_container-empty-d" if @completed_count && @completed_count == 0 && !@todo.completed?
       }
       page.context  {

--- a/app/views/todos/destroy.js.erb
+++ b/app/views/todos/destroy.js.erb
@@ -12,7 +12,7 @@
 
 function show_empty_messages() {
   <% if @old_due_empty -%>
-    $('#empty_<%=@original_item_due_id%>').slideDown(1000);
+    $('#empty_<%=get_due_id_for_calendar(@original_item.due)%>').slideDown(1000);
   <% end -%>
 
   <% if todo_container_is_empty -%>


### PR DESCRIPTION
Project uses properties of `@original_item` over a number of similar-named variables (eg. `@original_item_description`, `@original_item_was_pending`, etc.)

Have left in `@original_item_due_date` and `@original_completed_period` as these are more complex, and not simply properties of the todo item.

----

Tests pass, and playing around with todo items suggests that everything continues to work normally with this refactor in place.