### PR TITLE
Restyle the new todo forms

### DIFF
--- a/app/assets/stylesheets/legacy.scss
+++ b/app/assets/stylesheets/legacy.scss
@@ -14,7 +14,7 @@ div.depends_on label {
     float: left;
 }
 
-div#input_box div#todo_new_action_container div#todo_multi_add form#todo-form-multi-new-action.inline-form label {
+div#input_box div#todo_multi_add form#todo-form-multi-new-action.inline-form label {
     float: center;
 }
 
@@ -900,10 +900,12 @@ input#go_to_project, input#context_hide {
     text-align:right;
 }
 
-#todo-form-new-action label, .edit_todo_form label {
+.edit_todo_form label {
     display: block;
     padding-bottom: 3px;
 }
+
+
 
 form.button-to {
     border: none;

--- a/app/views/shared/_add_new_item_form.html.erb
+++ b/app/views/shared/_add_new_item_form.html.erb
@@ -7,7 +7,7 @@
 @initial_tags ||= @default_tags
 @initial_tags ||= @project.default_tags unless @project.nil?
 -%>
-<div id="todo_new_action_container">
+<div class="bootstrap" id="todo_new_action_container">
 
   <div id="toggle_forms" class="toggle_forms">
     <a title="<%= t('shared.hide_action_form_title') %>" accesskey="n" href="#" id="toggle_action_new"><%= t('shared.hide_form') %></a> |

--- a/app/views/shared/_add_new_item_form.html.erb
+++ b/app/views/shared/_add_new_item_form.html.erb
@@ -14,7 +14,7 @@
     <a title="<%= t('shared.toggle_multi_title') %>" accesskey="m" href="#" id="toggle_multi"><%= t('shared.toggle_multi') %></a>
   </div>
 
-  <%= render :partial => 'todos/new_todo_form', :object => Todo.new %>
-  <%= render :partial => 'todos/new_multi_todo_form', :object => Todo.new %>
+  <%= render :partial => 'todos/new_todo_form', :locals => {todo: Todo.new} %>
+  <%= render :partial => 'todos/new_multi_todo_form', :locals => {todo: Todo.new} %>
 
 </div>

--- a/app/views/todos/_new_multi_todo_form.html.erb
+++ b/app/views/todos/_new_multi_todo_form.html.erb
@@ -13,33 +13,40 @@
     <% end -%>
     </div>
 
-    <label for="todo_notes"><%= t('shared.multiple_next_actions') %></label>
-    <%= text_area_tag( "todo[multiple_todos]", "", :cols => 29, :rows => 6 ) %>
-
-    <label for="todo_project_name"><%= t('shared.project_for_all_actions') %></label>
-    <input id="multi_todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="<%=h @initial_project_name %>" />
-    <div class="page_name_auto_complete" id="project_list" style="display:none"></div>
-
-    <label for="todo_context_name"><%= t('shared.context_for_all_actions') %></label>
-    <input id="multi_todo_context_name" name="context_name" autocomplete="off" size="30" type="text" value="<%=h @initial_context_name %>" />
-    <div class="page_name_auto_complete" id="context_list" style="display:none"></div>
-
-    <label for="tag_list"><%= t('shared.tags_for_all_actions') %></label>
-    <%= hidden_field_tag "initial_tag_list", @initial_tags%>
-    <%= text_field_tag "multi_tag_list", @initial_tags, :name=>:tag_list, :size => 30 %>
-    <%= content_tag("div", "", :id => "tag_list_auto_complete", :class => "auto_complete") %>
-
-    <%= check_box_tag('todos_sequential', 'true', false) %>
-    <label for="todos_sequential"><%= t('shared.make_actions_dependent') %></label>
-
-    <div class="submit_box">
-      <div class="widgets">
-        <button type="submit" class="positive" id="todo_multi_new_action_submit">
-          <%=  image_tag("accept.png", :alt => "") %><%= t('shared.add_actions') %>
-        </button>
-      </div>
+    <div class="form-group">
+      <label for="todo_notes"><%= t('shared.multiple_next_actions') %></label>
+      <%= text_area_tag( "todo[multiple_todos]", "", :cols => 29, :rows => 6, :class => "form-control" ) %>
     </div>
 
+    <div class="form-group">
+      <label for="todo_project_name"><%= t('shared.project_for_all_actions') %></label>
+      <input class="form-control input-sm" id="multi_todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="<%=h @initial_project_name %>" />
+      <div class="page_name_auto_complete" id="project_list" style="display:none"></div>
+    </div>
+
+    <div class="form-group">
+      <label for="todo_context_name"><%= t('shared.context_for_all_actions') %></label>
+      <input class="form-control input-sm" id="multi_todo_context_name" name="context_name" autocomplete="off" size="30" type="text" value="<%=h @initial_context_name %>" />
+      <div class="page_name_auto_complete" id="context_list" style="display:none"></div>
+    </div>
+
+    <div class="form-group">
+      <label for="tag_list"><%= t('shared.tags_for_all_actions') %></label>
+      <%= hidden_field_tag "initial_tag_list", @initial_tags%>
+      <%= text_field_tag "multi_tag_list", @initial_tags, :name=>:tag_list, :size => 30, :class => "form-control input-sm" %>
+      <%= content_tag("div", "", :id => "tag_list_auto_complete", :class => "auto_complete") %>
+    </div>
+
+    <div class="form-group checkbox">
+      <label for="todos_sequential">
+        <%= check_box_tag('todos_sequential', 'true', false) %>
+        <%= t('shared.make_actions_dependent') %>
+      </label>
+    </div>
+
+    <button type="submit" class="btn btn-success" id="todo_multi_new_action_submit">
+      <%= t('shared.add_actions') %>
+    </button>
   <% end -%>
 
 </div>

--- a/app/views/todos/_new_multi_todo_form.html.erb
+++ b/app/views/todos/_new_multi_todo_form.html.erb
@@ -1,5 +1,3 @@
-<%- todo = new_multi_todo_form -%>
-
 <div id="todo_multi_add" style="display:none">
   <%= form_for(todo, :html=> { :id=>'todo-form-multi-new-action', :name=>'todo', :class => 'inline-form' }) do |t| %>
     <input id="default_project_name_id" name="default_project_name" type="hidden" value="<%=h @initial_project_name-%>" />

--- a/app/views/todos/_new_todo_form.html.erb
+++ b/app/views/todos/_new_todo_form.html.erb
@@ -8,56 +8,66 @@
       <%= get_list_of_error_messages_for(todo) %>
     </div>
 
-    <label for="todo_description" style="float:left"><%= Todo.human_attribute_name('description') %></label>
-    <a href="#" id="new_todo_starred_link" class="undecorated_link" ><%= image_tag("blank.png", :title =>t('todos.star_action'), :class => "todo_star", :style=> "float: right")%></a>
-    <%= t.text_field("description", "size" => 30, "maxlength" => 100, "autocomplete" => "off", :autofocus => true) %>
-
-    <label for="todo_notes"><%= Todo.human_attribute_name('notes') %></label>
-    <%= t.text_area("notes", "cols" => 29, "rows" => 6) %>
-
-    <label for="todo_project_name"><%= Todo.human_attribute_name('project') %></label>
-    <input id="todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="<%= h(@initial_project_name) %>" />
-    <div class="page_name_auto_complete" id="project_list" style="display:none"></div>
-
-    <label for="todo_context_name"><%= Todo.human_attribute_name('context') %></label>
-    <input id="todo_context_name" name="context_name" autocomplete="off" size="30" type="text" value="<%= h(@initial_context_name) %>" />
-
-    <label for="tag_list"><%= Todo.human_attribute_name('tags') + ' (' + t('shared.separate_tags_with_commas') + ')' %></label>
-    <%= hidden_field_tag "initial_tag_list", @initial_tags%>
-    <%= text_field_tag "tag_list", @initial_tags, :size => 30 %>
-    <%= content_tag("div", "", :id => "tag_list_auto_complete", :class => "auto_complete") %>
-
-    <div class="due_input">
-      <label for="todo_due"><%= Todo.human_attribute_name('due') %></label>
-      <%= t.text_field("due", "size" => 12, "class" => "Date", "autocomplete" => "off") %>
+    <div class="form-group">
+      <label for="todo_description" style="float:left"><%= Todo.human_attribute_name('description') %></label>
+      <a href="#" id="new_todo_starred_link" class="undecorated_link" ><%= image_tag("blank.png", :title =>t('todos.star_action'), :class => "todo_star", :style=> "float: right")%></a>
+      <%= t.text_field("description", "size" => 30, "maxlength" => 100, "autocomplete" => "off", :autofocus => true, :class => "form-control input-sm") %>
     </div>
 
-    <div class="show_from_input">
-      <label for="todo_show_from"><%= Todo.human_attribute_name('show_from') %></label>
-      <%= t.text_field("show_from", "size" => 12, "class" => "Date", "autocomplete" => "off") %>
+    <div class="form-group">
+      <label for="todo_notes"><%= Todo.human_attribute_name('notes') %></label>
+      <%= t.text_area("notes", "cols" => 29, "rows" => 6, :class => "form-control input-sm") %>
+    </div>
+
+    <div class="form-group">
+      <label for="todo_project_name"><%= Todo.human_attribute_name('project') %></label>
+      <input class="form-control input-sm" id="todo_project_name" name="project_name" autocomplete="off" size="30" type="text" value="<%= h(@initial_project_name) %>" />
+      <div class="page_name_auto_complete" id="project_list" style="display:none"></div>
+    </div>
+
+    <div class="form-group">
+      <label for="todo_context_name"><%= Todo.human_attribute_name('context') %></label>
+      <input class="form-control input-sm" id="todo_context_name" name="context_name" autocomplete="off" size="30" type="text" value="<%= h(@initial_context_name) %>" />
+    </div>
+
+    <div class="form-group">
+      <label for="tag_list"><%= Todo.human_attribute_name('tags') + ' (' + t('shared.separate_tags_with_commas') + ')' %></label>
+      <%= hidden_field_tag "initial_tag_list", @initial_tags%>
+      <%= text_field_tag "tag_list", @initial_tags, :size => 30, :class => "form-control input-sm" %>
+      <%= content_tag("div", "", :id => "tag_list_auto_complete", :class => "auto_complete") %>
+    </div>
+
+    <div class="form-group">
+      <div class="due_input">
+        <label for="todo_due"><%= Todo.human_attribute_name('due') %></label>
+        <%= t.text_field("due", "size" => 12, "class" => "Date form-control input-sm", "autocomplete" => "off") %>
+      </div>
+
+      <div class="show_from_input">
+        <label for="todo_show_from"><%= Todo.human_attribute_name('show_from') %></label>
+        <%= t.text_field("show_from", "size" => 12, "class" => "Date form-control input-sm", "autocomplete" => "off") %>
+      </div>
     </div>
 
     <div class="depends_on">
-      <label for="predecessor_ul"><%= Todo.human_attribute_name('predecessors')%></label>
-      <div class="selected_predecessors">
-        <ul class="predecessor_list" id="predecessor_ul" style="display:none">
-        </ul>
+      <div class="form-group">
+        <label for="predecessor_ul"><%= Todo.human_attribute_name('predecessors')%></label>
+        <div class="selected_predecessors">
+          <ul class="predecessor_list" id="predecessor_ul" style="display:none">
+          </ul>
+        </div>
+        <label id="label_for_predecessor_input" for="predecessor_input" style="display:none"><%= t('todos.add_another_dependency')%></label>
+        <%= text_field_tag "predecessor_input", nil, :size => 30, :class => "form-control input-sm" %>
       </div>
-      <label id="label_for_predecessor_input" for="predecessor_input" style="display:none"><%= t('todos.add_another_dependency')%></label>
-      <%= text_field_tag "predecessor_input", nil, :size => 30 %>
       <%= hidden_field_tag "predecessor_list", ""%>
     </div>
 
     <%= source_view_tag( @source_view ) %>
     <%= hidden_field_tag :_tag_name, @tag_name.underscore.gsub(/\s+/,'_') if source_view_is :tag %>
 
-    <div class="submit_box">
-      <div class="widgets">
-        <button type="submit" class="positive" id="todo_new_action_submit">
-          <%=  image_tag("accept.png", :alt => "") + t('shared.add_action') %>
-        </button>
-      </div>
-    </div>
+    <button type="submit" class="btn btn-success" id="todo_new_action_submit">
+      <%= t('shared.add_action') %>
+    </button>
 
   <% end # form_for -%>
 </div>

--- a/app/views/todos/_new_todo_form.html.erb
+++ b/app/views/todos/_new_todo_form.html.erb
@@ -1,5 +1,3 @@
-<%- todo = new_todo_form -%>
-
 <div id="todo_new_action">
   <%= form_for(todo, :html=> { :id=>'todo-form-new-action', :name=>'todo', :class => 'inline-form new_todo_form' }) do |t|%>
     <input id="default_project_name_id" name="default_project_name" type="hidden" value="<%= h(@initial_project_name)-%>" />


### PR DESCRIPTION
This PR restyles the new todo forms to provide more space for the text boxes and the UI overall.

Before:

![New todo form - before restyling](https://user-images.githubusercontent.com/77174/70376668-03d8e900-18d1-11ea-88b8-2ca74d2608c4.png)
<img width="303" alt="New multiple todo form - before restyling" src="https://user-images.githubusercontent.com/77174/70376671-04717f80-18d1-11ea-9d07-f278c5b9e988.png">

After:
![New todo form - after restyling](https://user-images.githubusercontent.com/77174/70376669-04717f80-18d1-11ea-959e-514d0176c39b.png)
<img width="307" alt="New multiple todo from - after restyling" src="https://user-images.githubusercontent.com/77174/70376670-04717f80-18d1-11ea-99df-97f8303f5d76.png">

This does make the forms take up more space but this looks way better.