### PR TITLE
Change "todos.description" from "string" to "text"

### DIFF
--- a/db/migrate/20200109231555_change_todo_description.rb
+++ b/db/migrate/20200109231555_change_todo_description.rb
@@ -1,0 +1,12 @@
+class ChangeTodoDescription < ActiveRecord::Migration[5.2]
+  def up 
+    change_table :todos do |t|
+      t.change :description, :text
+    end
+  end
+  def down
+    change_table :todos do |t|
+      t.change :description, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_18_202817) do
+ActiveRecord::Schema.define(version: 2020_01_09_231555) do
 
   create_table "attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "todo_id"
@@ -166,7 +166,7 @@ ActiveRecord::Schema.define(version: 2019_06_18_202817) do
   create_table "todos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "context_id", null: false
     t.integer "project_id"
-    t.string "description", null: false
+    t.text "description", null: false
     t.text "notes", limit: 16777215
     t.datetime "created_at"
     t.datetime "due"


### PR DESCRIPTION
DB field "todos.description" was type string, which
defaults to length 255 in MySQL. Model allows field
to be up to 300 characters, which could cause a DB
error, if user saved a description of between 255
and 300 characters.

Fixes #2274 