### PR TITLE
Modified installation instructions, to note that Ruby 2.7 is not tested.

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -10,7 +10,7 @@ For alternative installation options and tips for specific environments, please 
 
 Tracks has a few software requirements that must be satisfied before installation:
 
-1. **Ruby**. Tracks requires Ruby 2.4 or greater.
+1. **Ruby**. Tracks requires Ruby 2.4 or greater, but is not tested with 2.7.
 2. **Bundler**. Tracks requires a recent version of [Bundler](http://bundler.io) to handle the installation of dependencies. Bundler is typically installed by running `gem install bundler`.
 3. **Database**. Tracks is tested on [MySQL](http://www.mysql.com/) and [SQLite](http://www.sqlite.org/), but [PostgreSQL](http://www.postgresql.org/) can also be used. Of the three, SQLite requires the least configuration. Whatever your choice, the appropriate database software must be installed.
 


### PR DESCRIPTION
A very small update to the installation instructions, to point out that Ruby 2.7 is not tested.

I'm adding it, because in the way it's written at the moment "Tracks requires Ruby 2.4 or greater.", one can assume (as did I), that _all_versions greater than Ruby 2.4 are supported, and there seem to be some issues with 2.7.