### PR TITLE
Use Loofah::HTML5::SafeList where possible

### DIFF
--- a/config/initializers/sanitizer.rb
+++ b/config/initializers/sanitizer.rb
@@ -1,1 +1,10 @@
-Loofah::HTML5::WhiteList::ALLOWED_PROTOCOLS.merge(%w(message onenote))
+# From Loofah 2.3.0, we should use Loofah::HTML5::SafeList over
+# Loofah::HTML5::WhiteList
+safe_list =
+  if Loofah::HTML5.constants.include?(:SafeList)
+    Loofah::HTML5::SafeList
+  else
+    Loofah::HTML5::WhiteList
+  end
+
+safe_list::ALLOWED_PROTOCOLS.merge(%w(message onenote))


### PR DESCRIPTION
Another tiny quality-of-life improvement.

From Loofah 2.3.0, `Loofah::HTML5::WhiteList` is deprecated in favour of `Loofah::HTML5::SafeList`. This commit checks to see if `Loofah::HTML5::SafeList` exists, and uses it when it can.