### PR TITLE
Add solargraph as a developpment dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
 
   gem "bullet"
   gem "rack-mini-profiler"
+  gem "solargraph"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,9 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.4.7)
       execjs
+    backport (1.1.2)
     bcrypt (3.1.13)
+    benchmark (0.1.0)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -89,6 +91,7 @@ GEM
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.2)
+    e2mmap (0.1.0)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
@@ -123,6 +126,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    maruku (0.7.3)
     method_source (0.9.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -191,6 +195,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     ref (2.0.0)
+    reverse_markdown (1.4.0)
+      nokogiri
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -231,6 +237,20 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    solargraph (0.38.5)
+      backport (~> 1.1)
+      benchmark
+      bundler (>= 1.17.2)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      maruku (~> 0.7, >= 0.7.3)
+      nokogiri (~> 1.9, >= 1.9.1)
+      parser (~> 2.3)
+      reverse_markdown (~> 1.0, >= 1.0.5)
+      rubocop (~> 0.52)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9)
     spring (2.1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -303,6 +323,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver (~> 3.142)
   simplecov
+  solargraph
   spring
   sqlite3
   therubyracer
@@ -312,4 +333,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
This allows developers to take advantage of the better information you can get from editors that will integrate with this gem and the language server protocol.