### PR TITLE
Update the base image for docker to ruby 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.6
 
 WORKDIR /app
 


### PR DESCRIPTION
What it says on the tin. Newer versions of Rails require newer versions of Ruby. Let's upgrade.