### PR TITLE
Use the right format for expiry_time

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -77,7 +77,7 @@ class LoginController < ApplicationController
 
   def expiry_time
     return Time.now + 10 unless session['expiry_time']
-    DateTime.strptime(session['expiry_time'], "%FT%T%Z")
+    DateTime.strptime(session['expiry_time'], "%FT%T.%L%Z")
   end
 
 end


### PR DESCRIPTION
This should finally fix the exception seen when the app checks session expire time.