### PR TITLE
Fix contribute link in footer and prefer HTTPS

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,9 +4,9 @@
     <span class="footer-line">
       <a href="https://github.com/TracksApp/tracks/issues"><%= t('common.bugs')%></a> |
       <a href="https://github.com/TracksApp/tracks/wiki"><%= t('common.wiki')%></a> |
-      <a href="http://groups.google.com/group/TracksApp"><%= t('common.mailing_list')%></a> |
-      <a href="http://www.getontracks.org/"><%= t('common.website')%></a> |
-      <a href="http://www.getontracks.org/development/"><%= t('common.contribute')%></a> |
+      <a href="https://groups.google.com/group/TracksApp"><%= t('common.mailing_list')%></a> |
+      <a href="https://www.getontracks.org/"><%= t('common.website')%></a> |
+      <a href="https://www.getontracks.org/contribute/"><%= t('common.contribute')%></a> |
       <%= link_to(t('layouts.navigation.mobile'), todos_path(:format => 'm')) %>
     </span>
   </div>


### PR DESCRIPTION
The "Contribute" link in the footer returns a 404, so have changed to the most relevant looking page.
Also changed all http links to https after confirming they have valid https endpoints.

Note that I haven't run the rake tests because Ive just changed a couple of links (and haven't yet got everything up and running locally).  do let me know if I need to do this!