### PR TITLE
Redo the datepicker z-index fix that didn't work because it has been …

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,3 +53,7 @@ body {
   color: $text-color;
   background-color: $body-bg;
 }
+
+.ui-datepicker {
+  z-index: 999999 !important;
+}

--- a/app/assets/stylesheets/legacy.scss
+++ b/app/assets/stylesheets/legacy.scss
@@ -1349,10 +1349,6 @@ div.auto_complete {
     }
 }
 
-.ui-datepicker {
-    z-index: 1000 !important;
-}
-
 .ui-autocomplete-loading {
     background: white image-url('ui-anim_basic_16x16.gif') right center no-repeat;
 }


### PR DESCRIPTION
…applied only to the div.legacy, but as datepicker is appended to the end of the document it's outside the element. Also making the number a lot bigger to account for a large amount of tasks, which cause higher z-indexes.

Fixes #2245.