### PR TITLE
Towards fixing #2630

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,6 @@ group :test do
   gem 'rspec-expectations'
   gem 'simplecov'
 end
+
+gem "mini_racer"
+


### PR DESCRIPTION
There is already gem 'therubyracer', group: :therubyracer , but it was still failing due to a missing JS engine when installing on Ubuntu 20.04