### PR TITLE
Parse the session expiry time to a Time instead of DateTime to allow …

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -80,6 +80,6 @@ class LoginController < ApplicationController
 
   def expiry_time
     return Time.zone.now + 10 unless session['expiry_time']
-    DateTime.strptime(session['expiry_time'], "%FT%T.%L%Z")
+    Time.zone.parse(session['expiry_time'])
   end
 end


### PR DESCRIPTION
…comparison.

Fixes #2581.