### PR TITLE
Allow autocompletion behind proxy

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module Tracksapp
 
     # configure Tracks to handle deployment in a subdir
     config.relative_url_root = SITE_CONFIG['subdir'] if SITE_CONFIG['subdir']
+    # or deployment behind a proxy
+    config.action_controller.default_url_options = SITE_CONFIG['default_url_options'] if SITE_CONFIG['default_url_options']
   end
 end

--- a/config/site.yml.tmpl
+++ b/config/site.yml.tmpl
@@ -39,6 +39,13 @@ force_ssl: false
 # the relative URL. Mongrel, for example, has a --prefix option.
 # subdir: "/tracks"
 
+# Set this to respective values if you're instance is running behind a proxy
+# (e.g. localhost:3000 is not the client visible host).
+# default_url_options:
+#   :host: 'example.org'
+#   :protocol: 'https://'
+#   :port: 443
+
 # Set to true to allow anyone to sign up for a username.
 open_signups: false
 


### PR DESCRIPTION
When the application is exposed via proxy, i.e. client visible host
(e.g. example.org:443) is different than Ruby server (e.g.
localhost:3000), autocompletion does not work since the generated URLs
refer to the internal hostname.

The AJAX is constructed with root_url and that can be modified with
default_url_options. So the simple fix just allows specifying customized
default_url_options.

Fixes: #1416