### PR TITLE
Install older version of Bundler in CI for Ruby 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 RUN touch /etc/app-env
 
 COPY Gemfile* /app/
-RUN gem install bundler
+RUN gem install bundler -v 2.4.22
 RUN bundle install --jobs 4
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
Pin Bundler to 2.4.22 so that 2.7 CI keeps working.
