### PR TITLE
Gemfile: move asset gems to 'default' (rm 'assets' section)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,13 @@ gem 'rails', '~> 6.1'
 gem 'font-awesome-sass', '~> 6.5.2'
 gem 'jquery-rails', '~> 4.6'
 gem 'jquery-ui-rails', '~>7.0.0'
+gem 'coffee-rails', '~> 5.0.0'
+gem 'sassc-rails', '~> 2.1.2'
+gem 'bootstrap-sass', '3.4.1'
+gem 'uglifier', '>=1.3.0'
+gem 'listen'
+gem 'tolk', '~> 5.0.1'
+
 gem 'aasm', '~> 5.5.0'
 gem 'acts_as_list'
 gem 'bcrypt', '~> 3.1.20'
@@ -27,15 +34,6 @@ gem 'pg', '~> 1.5', group: :postgresql
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 gem 'mini_racer', group: :therubyracer
-
-group :assets do
-  gem 'coffee-rails', '~> 5.0.0'
-  gem 'sassc-rails', '~> 2.1.2'
-  gem 'bootstrap-sass', '3.4.1'
-  gem 'uglifier', '>=1.3.0'
-  gem 'listen'
-  gem 'tolk', '~> 5.0.1'
-end
 
 group :development, :optional => true do
   gem 'spring', '~> 4'


### PR DESCRIPTION
Hi @ZeiP :wave: :sunglasses: 

I'm no RoR expert, but this seems like the "right" fix for #3065?! My rationale is [here](https://github.com/TracksApp/tracks/issues/3065#issuecomment-2400803381).

If you don't like this approach please share your preferred path and I'll have another stab. I'd also be really interested in your rationale.

Update `Gemfile`:
- remove `assets` section
- move asset related gems (from removed section) to `default`
- group asset related gems together for easier reading
- closes #3065 

---

FYI I haven't explicitly tested as per [`CONTRIBUTING.md`](https://github.com/TracksApp/tracks/blob/8abfafa0c6a33db9c9dc545ed2180a71817e5416/CONTRIBUTING.md#enhancements).

I have tested in a chroot during [TKL Tracks app v18.1 update](https://github.com/turnkeylinux-apps/tracks/pull/22) dev. I'll also do a final pre-release smoke test. Others have also confirmed a similar "fix" in #3065. Hopefully that's good enough?