### PR TITLE
Upgrade to Rails 7.1 and add some environment fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,15 +31,12 @@ gem 'pg', '~> 1.5', group: :postgresql
 gem 'mini_racer', group: :therubyracer
 
 gem 'sprockets-rails'
-
-group :assets do
-  gem 'coffee-rails', '~> 5.0.0'
-  gem 'dartsass-sprockets'
-  gem 'bootstrap-sass', '3.4.1'
-  gem 'uglifier', '>=1.3.0'
-  gem 'listen'
-  gem 'tolk', '~> 6.0.0'
-end
+gem 'coffee-rails', '~> 5.0.0'
+gem 'dartsass-sprockets'
+gem 'bootstrap-sass', '3.4.1'
+gem 'terser'
+gem 'listen'
+gem 'tolk', '~> 6.0.0'
 
 group :development, :optional => true do
   gem 'spring', '~> 4'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'actionpack-xml_parser', '~> 2.0'
 gem 'activemodel-serializers-xml', '~> 1.0.3'
 
-gem 'rails', '~> 7.0'
+gem 'rails', '~> 7.1'
 
 gem 'font-awesome-sass', '~> 6.7.2'
 gem 'jquery-rails', '~> 4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
       mime-types
       terrapin (~> 0.6.0)
     language_server-protocol (3.17.0.3)
-    libv8-node (21.7.2.0)
+    libv8-node (24.1.0.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -211,8 +211,8 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    mini_racer (0.12.0)
-      libv8-node (~> 21.7.2.0)
+    mini_racer (0.19.0)
+      libv8-node (~> 24.1.0.0)
     minitest (5.25.5)
     minitest-stub-const (0.6)
     mocha (2.7.1)
@@ -383,6 +383,8 @@ GEM
       unicode-display_width (>= 1.1.1, < 4)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
+    terser (1.2.6)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -393,8 +395,6 @@ GEM
       rails (>= 3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -453,9 +453,9 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 2.7)
   stripe
+  terser
   tolk (~> 6.0.0)
   tracks-chartjs-ror
-  uglifier (>= 1.3.0)
   will_paginate
   yard
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ DEPENDENCIES
   pg (~> 1.5)
   puma (~> 6.6)
   rack-mini-profiler
-  rails (~> 7.0)
+  rails (~> 7.1)
   rails-controller-testing
   rails-dom-testing (~> 2.2.0)
   rails_autolink

--- a/bin/rake
+++ b/bin/rake
@@ -9,5 +9,5 @@ if [ -e $SCRIPTPATH/../.use-docker -a ! -e /etc/app-env ];
 then
   $SCRIPTPATH/../script/docker-environment $0 "$@"
 else
-  $SCRIPTPATH/run-rake "$@"
+  bundle exec rake "$@"
 fi

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,8 +21,7 @@ module Tracksapp
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
-#    config.autoload_paths += %W(#{config.root}/lib)
-    config.eager_load_paths += %W(#{config.root}/lib)
+    config.autoload_lib(ignore: %w(assets tasks))
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ SITE_CONFIG = YAML.load_file(File.join(File.dirname(__FILE__), 'site.yml'))
 module Tracksapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Terser.new
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
   db:
-    image: mysql:5.7
+    image: mariadb:lts
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 1
-      MYSQL_DATABASE: ${TRACKS_DB:-tracks}
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
+      MARIADB_DATABASE: ${TRACKS_DB:-tracks}
     volumes:
       - db-data:/var/lib/mysql
   web:

--- a/script/poll-for-db
+++ b/script/poll-for-db
@@ -2,7 +2,7 @@
 
 echo "==> Polling DB…"
 
-if [ "$1" == "mysql" ]; then
+if [ -z "$1" ] || [ "$1" == "mysql" ]; then
   appdir=$(cd $(dirname "$0")/.. && pwd)
   [ -f /etc/app-env ] || exec "$appdir/script/docker-environment" $0 $@
 

--- a/test-envs/docker-compose-mysql.yml
+++ b/test-envs/docker-compose-mysql.yml
@@ -1,9 +1,9 @@
 services:
   db:
-    image: mysql:5.7
+    image: mariadb:lts
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 1
-      MYSQL_DATABASE: ${TRACKS_DB:-tracks}
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
+      MARIADB_DATABASE: ${TRACKS_DB:-tracks}
   web:
     build:
       context: ..


### PR DESCRIPTION
Fixes #3066
Fixes #3065 

Decided to move the theme compilation stuff from under the asset group to the default group as suggested also in #3066. The rationale for the separate group would be to limit the amount of libraries in the production container; however it can be argued that the production container should also be able to build it's image. Additionally it seems that having it under a separate group would also require all asset precompilation to include the RAILS_GROUPS environment variable (as that also affects the gems required automatically in config/application.rb row `Bundler.require(*Rails.groups)`). So basically it seems like unnecessary hassle to have it separate, as having the extra code in the container isn't all that problematic, if not optimal either.